### PR TITLE
feat: 알림 읽음/미읽음 UI, 클릭 네비게이션, 홈 배지 구현 

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "WebFetch(domain:www.figma.com)",
       "mcp__plugin_figma_figma__get_screenshot",
       "mcp__plugin_figma_figma__get_design_context",
-      "mcp__plugin_figma_figma__get_metadata"
+      "mcp__plugin_figma_figma__get_metadata",
+      "mcp__plugin_figma_figma__whoami"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "WebFetch(domain:www.figma.com)",
       "mcp__plugin_figma_figma__get_screenshot",
-      "mcp__plugin_figma_figma__get_design_context"
+      "mcp__plugin_figma_figma__get_design_context",
+      "mcp__plugin_figma_figma__get_metadata"
     ]
   }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.okhttp.logging)
     implementation(libs.mpandroidchart)
     implementation(libs.glide)
+    implementation(libs.androidx.swiperefreshlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/reday/InquiryAdapter.kt
+++ b/app/src/main/java/com/example/reday/InquiryAdapter.kt
@@ -14,7 +14,7 @@ data class InquiryAnswer(
 )
 
 data class InquiryUiModel(
-    val id: Int,
+    val id: Long,
     val userName: String,
     val date: String,
     val title: String,
@@ -23,7 +23,8 @@ data class InquiryUiModel(
 )
 
 class InquiryAdapter(
-    private val items: List<InquiryUiModel>
+    private val items: List<InquiryUiModel>,
+    private val onItemClick: (InquiryUiModel) -> Unit = {}
 ) : RecyclerView.Adapter<InquiryAdapter.InquiryViewHolder>() {
 
     inner class InquiryViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -46,6 +47,8 @@ class InquiryAdapter(
 
     override fun onBindViewHolder(holder: InquiryViewHolder, position: Int) {
         val item = items[position]
+        holder.itemView.setOnClickListener { onItemClick(item) }
+
         holder.tvUserName.text = item.userName
         holder.tvDate.text = item.date
         holder.tvTitle.text = item.title

--- a/app/src/main/java/com/example/reday/InquiryDetailFragment.kt
+++ b/app/src/main/java/com/example/reday/InquiryDetailFragment.kt
@@ -1,0 +1,88 @@
+package com.example.reday
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.example.reday.data.remote.RetrofitClient
+import com.google.android.material.card.MaterialCardView
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class InquiryDetailFragment : Fragment() {
+
+    companion object {
+        const val ARG_INQUIRY_ID = "inquiry_id"
+        const val ARG_TITLE = "inquiry_title"
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_inquiry_detail, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val inquiryId = arguments?.getLong(ARG_INQUIRY_ID) ?: -1L
+        val titlePreview = arguments?.getString(ARG_TITLE) ?: ""
+
+        val tvTitle = view.findViewById<TextView>(R.id.tv_inquiry_title)
+        val tvDate = view.findViewById<TextView>(R.id.tv_inquiry_date)
+        val tvContent = view.findViewById<TextView>(R.id.tv_inquiry_content)
+        val layoutPending = view.findViewById<LinearLayout>(R.id.layout_answer_pending)
+        val layoutReceived = view.findViewById<MaterialCardView>(R.id.layout_answer_received)
+        val tvAnswerAuthor = view.findViewById<TextView>(R.id.tv_answer_author)
+        val tvAnswerDate = view.findViewById<TextView>(R.id.tv_answer_date)
+        val tvAnswerContent = view.findViewById<TextView>(R.id.tv_answer_content)
+
+        tvTitle.text = titlePreview
+
+        view.findViewById<View>(R.id.btn_back).setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.inquiryApi.getInquiryDetail(inquiryId)
+                val data = response.data
+
+                tvTitle.text = data.title
+                tvDate.text = formatDate(data.createdAt)
+                tvContent.text = data.content
+
+                if (data.status == "ANSWERED" && data.replyContent != null) {
+                    layoutPending.visibility = View.GONE
+                    layoutReceived.visibility = View.VISIBLE
+                    tvAnswerAuthor.text = "Re:Day 팀"
+                    tvAnswerDate.text = data.repliedAt?.let { formatDate(it) } ?: ""
+                    tvAnswerContent.text = data.replyContent
+                } else {
+                    layoutPending.visibility = View.VISIBLE
+                    layoutReceived.visibility = View.GONE
+                }
+            } catch (_: Exception) {
+                tvContent.text = "문의 내용을 불러오지 못했습니다."
+                layoutPending.visibility = View.VISIBLE
+                layoutReceived.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun formatDate(dateTime: String): String {
+        return try {
+            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            "${parsed.year}. ${parsed.monthValue.toString().padStart(2, '0')}. ${parsed.dayOfMonth.toString().padStart(2, '0')}."
+        } catch (_: Exception) {
+            dateTime.take(10)
+        }
+    }
+}

--- a/app/src/main/java/com/example/reday/InquiryFragment.kt
+++ b/app/src/main/java/com/example/reday/InquiryFragment.kt
@@ -5,8 +5,15 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.example.reday.data.remote.InquiryListDto
+import com.example.reday.data.remote.RetrofitClient
+import com.example.reday.utils.TokenManager
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class InquiryFragment : Fragment() {
 
@@ -32,40 +39,67 @@ class InquiryFragment : Fragment() {
                 .commit()
         }
 
-        val items = listOf(
-            InquiryUiModel(
-                id = 1,
-                userName = "사용자",
-                date = "2024. 11. 29.",
-                title = "기억 생성 오류 문의",
-                content = "기억 생성 버튼을 눌러도 AI 생성이 시작되지 않습니다.",
-                answer = null
-            ),
-            InquiryUiModel(
-                id = 2,
-                userName = "사용자",
-                date = "2024. 11. 29.",
-                title = "앱 사용 방법 문의",
-                content = "기록 조각을 추가하는 방법을 알고 싶습니다.",
-                answer = InquiryAnswer(
-                    authorName = "Re:Day 팀",
-                    date = "2024. 11. 29.",
-                    content = "안녕하세요! 홈 화면 하단의 + 버튼을 눌러 기록 조각을 추가하실 수 있습니다."
-                )
-            )
-        )
-
         val rvInquiries = view.findViewById<RecyclerView>(R.id.rv_inquiries)
         val layoutEmpty = view.findViewById<View>(R.id.layout_empty)
 
-        if (items.isEmpty()) {
-            rvInquiries.visibility = View.GONE
-            layoutEmpty.visibility = View.VISIBLE
-        } else {
-            rvInquiries.visibility = View.VISIBLE
-            layoutEmpty.visibility = View.GONE
-            rvInquiries.layoutManager = LinearLayoutManager(requireContext())
-            rvInquiries.adapter = InquiryAdapter(items)
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.inquiryApi.getInquiries()
+                val userName = TokenManager.getUserName(requireContext()).ifBlank { "사용자" }
+                val items = response.data.map { it.toUiModel(userName) }
+
+                if (items.isEmpty()) {
+                    rvInquiries.visibility = View.GONE
+                    layoutEmpty.visibility = View.VISIBLE
+                } else {
+                    rvInquiries.visibility = View.VISIBLE
+                    layoutEmpty.visibility = View.GONE
+                    rvInquiries.layoutManager = LinearLayoutManager(requireContext())
+                    rvInquiries.adapter = InquiryAdapter(items) { inquiry ->
+                        val fragment = InquiryDetailFragment().apply {
+                            arguments = Bundle().apply {
+                                putLong(InquiryDetailFragment.ARG_INQUIRY_ID, inquiry.id)
+                                putString(InquiryDetailFragment.ARG_TITLE, inquiry.title)
+                            }
+                        }
+                        parentFragmentManager.beginTransaction()
+                            .replace(R.id.content_container, fragment)
+                            .addToBackStack(null)
+                            .commit()
+                    }
+                }
+            } catch (_: Exception) {
+                rvInquiries.visibility = View.GONE
+                layoutEmpty.visibility = View.VISIBLE
+            }
+        }
+    }
+
+    private fun InquiryListDto.toUiModel(userName: String): InquiryUiModel {
+        val answer = if (status == "ANSWERED" && replyContent != null) {
+            InquiryAnswer(
+                authorName = "Re:Day 팀",
+                date = "",
+                content = replyContent
+            )
+        } else null
+
+        return InquiryUiModel(
+            id = inquiryId,
+            userName = userName,
+            date = formatDate(createdAt),
+            title = title,
+            content = contentPreview,
+            answer = answer
+        )
+    }
+
+    private fun formatDate(dateTime: String): String {
+        return try {
+            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            "${parsed.year}. ${parsed.monthValue.toString().padStart(2, '0')}. ${parsed.dayOfMonth.toString().padStart(2, '0')}."
+        } catch (_: Exception) {
+            dateTime.take(10)
         }
     }
 }

--- a/app/src/main/java/com/example/reday/InquiryFragment.kt
+++ b/app/src/main/java/com/example/reday/InquiryFragment.kt
@@ -8,12 +8,12 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.reday.data.remote.InquiryListDto
 import com.example.reday.data.remote.RetrofitClient
 import com.example.reday.utils.TokenManager
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.time.ZonedDateTime
 
 class InquiryFragment : Fragment() {
 
@@ -39,40 +39,50 @@ class InquiryFragment : Fragment() {
                 .commit()
         }
 
+        val swipeRefresh = view.findViewById<SwipeRefreshLayout>(R.id.swipe_refresh)
         val rvInquiries = view.findViewById<RecyclerView>(R.id.rv_inquiries)
         val layoutEmpty = view.findViewById<View>(R.id.layout_empty)
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                val response = RetrofitClient.inquiryApi.getInquiries()
-                val userName = TokenManager.getUserName(requireContext()).ifBlank { "사용자" }
-                val items = response.data.map { it.toUiModel(userName) }
+        swipeRefresh.setColorSchemeResources(R.color.main_200)
 
-                if (items.isEmpty()) {
+        fun loadInquiries() {
+            viewLifecycleOwner.lifecycleScope.launch {
+                try {
+                    val response = RetrofitClient.inquiryApi.getInquiries()
+                    val userName = TokenManager.getUserName(requireContext()).ifBlank { "사용자" }
+                    val items = response.data.map { it.toUiModel(userName) }
+
+                    if (items.isEmpty()) {
+                        rvInquiries.visibility = View.GONE
+                        layoutEmpty.visibility = View.VISIBLE
+                    } else {
+                        rvInquiries.visibility = View.VISIBLE
+                        layoutEmpty.visibility = View.GONE
+                        rvInquiries.layoutManager = LinearLayoutManager(requireContext())
+                        rvInquiries.adapter = InquiryAdapter(items) { inquiry ->
+                            val fragment = InquiryDetailFragment().apply {
+                                arguments = Bundle().apply {
+                                    putLong(InquiryDetailFragment.ARG_INQUIRY_ID, inquiry.id)
+                                    putString(InquiryDetailFragment.ARG_TITLE, inquiry.title)
+                                }
+                            }
+                            parentFragmentManager.beginTransaction()
+                                .replace(R.id.content_container, fragment)
+                                .addToBackStack(null)
+                                .commit()
+                        }
+                    }
+                } catch (_: Exception) {
                     rvInquiries.visibility = View.GONE
                     layoutEmpty.visibility = View.VISIBLE
-                } else {
-                    rvInquiries.visibility = View.VISIBLE
-                    layoutEmpty.visibility = View.GONE
-                    rvInquiries.layoutManager = LinearLayoutManager(requireContext())
-                    rvInquiries.adapter = InquiryAdapter(items) { inquiry ->
-                        val fragment = InquiryDetailFragment().apply {
-                            arguments = Bundle().apply {
-                                putLong(InquiryDetailFragment.ARG_INQUIRY_ID, inquiry.id)
-                                putString(InquiryDetailFragment.ARG_TITLE, inquiry.title)
-                            }
-                        }
-                        parentFragmentManager.beginTransaction()
-                            .replace(R.id.content_container, fragment)
-                            .addToBackStack(null)
-                            .commit()
-                    }
+                } finally {
+                    swipeRefresh.isRefreshing = false
                 }
-            } catch (_: Exception) {
-                rvInquiries.visibility = View.GONE
-                layoutEmpty.visibility = View.VISIBLE
             }
         }
+
+        swipeRefresh.setOnRefreshListener { loadInquiries() }
+        loadInquiries()
     }
 
     private fun InquiryListDto.toUiModel(userName: String): InquiryUiModel {
@@ -96,7 +106,7 @@ class InquiryFragment : Fragment() {
 
     private fun formatDate(dateTime: String): String {
         return try {
-            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            val parsed = ZonedDateTime.parse(dateTime).toLocalDate()
             "${parsed.year}. ${parsed.monthValue.toString().padStart(2, '0')}. ${parsed.dayOfMonth.toString().padStart(2, '0')}."
         } catch (_: Exception) {
             dateTime.take(10)

--- a/app/src/main/java/com/example/reday/InquiryWriteFragment.kt
+++ b/app/src/main/java/com/example/reday/InquiryWriteFragment.kt
@@ -7,6 +7,10 @@ import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.example.reday.data.remote.InquiryCreateRequest
+import com.example.reday.data.remote.RetrofitClient
+import kotlinx.coroutines.launch
 
 class InquiryWriteFragment : Fragment() {
 
@@ -21,13 +25,17 @@ class InquiryWriteFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val etTitle = view.findViewById<EditText>(R.id.et_inquiry_title)
+        val etContent = view.findViewById<EditText>(R.id.et_inquiry_content)
+        val btnSend = view.findViewById<View>(R.id.btn_send_inquiry)
+
         view.findViewById<View>(R.id.btn_back).setOnClickListener {
             parentFragmentManager.popBackStack()
         }
 
-        view.findViewById<View>(R.id.btn_send_inquiry).setOnClickListener {
-            val title = view.findViewById<EditText>(R.id.et_inquiry_title).text.toString().trim()
-            val content = view.findViewById<EditText>(R.id.et_inquiry_content).text.toString().trim()
+        btnSend.setOnClickListener {
+            val title = etTitle.text.toString().trim()
+            val content = etContent.text.toString().trim()
 
             if (title.isEmpty()) {
                 Toast.makeText(requireContext(), "제목을 입력해주세요.", Toast.LENGTH_SHORT).show()
@@ -38,8 +46,17 @@ class InquiryWriteFragment : Fragment() {
                 return@setOnClickListener
             }
 
-            Toast.makeText(requireContext(), "문의가 접수되었습니다.", Toast.LENGTH_SHORT).show()
-            parentFragmentManager.popBackStack()
+            btnSend.isEnabled = false
+            viewLifecycleOwner.lifecycleScope.launch {
+                try {
+                    RetrofitClient.inquiryApi.createInquiry(InquiryCreateRequest(title, content))
+                    Toast.makeText(requireContext(), "문의가 접수되었습니다.", Toast.LENGTH_SHORT).show()
+                    parentFragmentManager.popBackStack()
+                } catch (_: Exception) {
+                    Toast.makeText(requireContext(), "문의 전송에 실패했습니다. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                    btnSend.isEnabled = true
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/reday/MainActivity.kt
+++ b/app/src/main/java/com/example/reday/MainActivity.kt
@@ -10,9 +10,11 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import android.view.View
 import android.widget.TextView
+import androidx.lifecycle.lifecycleScope
 import com.example.reday.data.remote.RetrofitClient
 import com.example.reday.utils.TokenManager
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
@@ -39,7 +41,11 @@ class MainActivity : AppCompatActivity() {
             bottomNav?.visibility = if (shouldHide) View.GONE else View.VISIBLE
             divider?.visibility = if (shouldHide) View.GONE else View.VISIBLE
             appHeader?.visibility = if (shouldHide) View.GONE else View.VISIBLE
+            // 알림 화면에서 나올 때 배지 재확인
+            if (!shouldHide) updateNotificationBadge()
         }
+
+        updateNotificationBadge()
     }
 
     private fun setupBottomNavigation() {
@@ -118,6 +124,19 @@ class MainActivity : AppCompatActivity() {
                 .replace(R.id.content_container, NotificationFragment())
                 .addToBackStack(null)
                 .commit()
+        }
+    }
+
+    fun updateNotificationBadge() {
+        lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.notificationApi.getNotifications("ALL")
+                val hasUnread = response.data.any { !it.isRead }
+                findViewById<View>(R.id.badge_notification)?.visibility =
+                    if (hasUnread) View.VISIBLE else View.GONE
+            } catch (_: Exception) {
+                // 실패 시 배지 유지
+            }
         }
     }
 

--- a/app/src/main/java/com/example/reday/NoticeAdapter.kt
+++ b/app/src/main/java/com/example/reday/NoticeAdapter.kt
@@ -7,7 +7,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
 data class NoticeUiModel(
-    val id: Int,
+    val id: Long,
     val title: String,
     val preview: String,
     val time: String,

--- a/app/src/main/java/com/example/reday/NoticeDetailFragment.kt
+++ b/app/src/main/java/com/example/reday/NoticeDetailFragment.kt
@@ -6,13 +6,17 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.example.reday.data.remote.RetrofitClient
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class NoticeDetailFragment : Fragment() {
 
     companion object {
+        const val ARG_NOTICE_ID = "notice_id"
         const val ARG_TITLE = "notice_title"
-        const val ARG_DATE = "notice_date"
-        const val ARG_CONTENT = "notice_content"
     }
 
     override fun onCreateView(
@@ -26,16 +30,39 @@ class NoticeDetailFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val noticeId = arguments?.getLong(ARG_NOTICE_ID) ?: -1L
         val title = arguments?.getString(ARG_TITLE) ?: ""
-        val date = arguments?.getString(ARG_DATE) ?: ""
-        val content = arguments?.getString(ARG_CONTENT) ?: ""
 
-        view.findViewById<TextView>(R.id.tv_toolbar_title).text = title
-        view.findViewById<TextView>(R.id.tv_notice_date).text = date
-        view.findViewById<TextView>(R.id.tv_notice_content).text = content
+        val tvToolbarTitle = view.findViewById<TextView>(R.id.tv_toolbar_title)
+        val tvDate = view.findViewById<TextView>(R.id.tv_notice_date)
+        val tvContent = view.findViewById<TextView>(R.id.tv_notice_content)
+
+        tvToolbarTitle.text = title
 
         view.findViewById<View>(R.id.btn_back).setOnClickListener {
             parentFragmentManager.popBackStack()
+        }
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.noticeApi.getNoticeDetail(noticeId)
+                val data = response.data
+                tvToolbarTitle.text = data.title
+                tvDate.text = formatDate(data.createdAt)
+                tvContent.text = data.content
+            } catch (_: Exception) {
+                tvDate.text = ""
+                tvContent.text = "공지사항을 불러오지 못했습니다."
+            }
+        }
+    }
+
+    private fun formatDate(dateTime: String): String {
+        return try {
+            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            "${parsed.year}. ${parsed.monthValue.toString().padStart(2, '0')}. ${parsed.dayOfMonth.toString().padStart(2, '0')}."
+        } catch (_: Exception) {
+            dateTime.take(10)
         }
     }
 }

--- a/app/src/main/java/com/example/reday/NoticeFragment.kt
+++ b/app/src/main/java/com/example/reday/NoticeFragment.kt
@@ -5,8 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.example.reday.data.remote.NoticeListDto
+import com.example.reday.data.remote.RetrofitClient
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class NoticeFragment : Fragment() {
 
@@ -25,59 +31,59 @@ class NoticeFragment : Fragment() {
             parentFragmentManager.popBackStack()
         }
 
-        val items = listOf(
-            NoticeUiModel(
-                id = 1,
-                title = "12월 업데이트 안내",
-                preview = "새로운 기능이 추가되었습니다! 기억 카드 꾸미기 기능을 확인해보세요.",
-                time = "5분 전",
-                isRead = false,
-                date = "2024. 12. 01.  16:00",
-                content = "안녕하세요, Re:Day입니다.\n\n12월 업데이트 내용을 안내드립니다.\n\n1. 기억 카드 꾸미기 기능 추가\n기억 카드에 스티커와 배경을 추가할 수 있는 기능이 추가되었습니다.\n\n2. 지도 기능 개선\n기억의 위치 정보를 더 정확하게 표시하도록 개선되었습니다.\n\n3. 성능 향상\n앱 전반의 로딩 속도가 개선되었습니다.\n\n이용해 주셔서 감사합니다."
-            ),
-            NoticeUiModel(
-                id = 2,
-                title = "서비스 업데이트 안내",
-                preview = "이번 달부터 AI 기억 생성 기능이 더욱 향상되었습니다.",
-                time = "1일 전",
-                isRead = false,
-                date = "2024. 11. 30.  10:00",
-                content = "안녕하세요, Re:Day입니다.\n\nAI 기억 생성 기능이 업그레이드되었습니다.\n\n- 더욱 자연스러운 기억 제목 생성\n- 감정 분석 기능 추가\n- 태그 자동 추천 개선\n\n앞으로도 더 좋은 서비스로 찾아오겠습니다."
-            ),
-            NoticeUiModel(
-                id = 3,
-                title = "서비스 점검 완료 안내",
-                preview = "11월 25일 새벽 2시~4시 진행된 서비스 점검이 완료되었습니다.",
-                time = "5일 전",
-                isRead = true,
-                date = "2024. 11. 25.  04:00",
-                content = "안녕하세요, Re:Day입니다.\n\n11월 25일 새벽 2시~4시에 진행된 정기 서비스 점검이 완료되었습니다.\n\n점검 내용:\n- 서버 안정성 강화\n- 데이터베이스 최적화\n- 보안 패치 적용\n\n이용에 불편을 드려 죄송합니다.\n앞으로도 안정적인 서비스를 제공하기 위해 최선을 다하겠습니다."
-            )
-        )
-
         val rvNotices = view.findViewById<RecyclerView>(R.id.rv_notices)
         val layoutEmpty = view.findViewById<View>(R.id.layout_empty)
 
-        if (items.isEmpty()) {
-            rvNotices.visibility = View.GONE
-            layoutEmpty.visibility = View.VISIBLE
-        } else {
-            rvNotices.visibility = View.VISIBLE
-            layoutEmpty.visibility = View.GONE
-            rvNotices.layoutManager = LinearLayoutManager(requireContext())
-            rvNotices.adapter = NoticeAdapter(items) { notice ->
-                val fragment = NoticeDetailFragment().apply {
-                    arguments = Bundle().apply {
-                        putString(NoticeDetailFragment.ARG_TITLE, notice.title)
-                        putString(NoticeDetailFragment.ARG_DATE, notice.date)
-                        putString(NoticeDetailFragment.ARG_CONTENT, notice.content)
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.noticeApi.getNotices()
+                val items = response.data.map { it.toUiModel() }
+
+                if (items.isEmpty()) {
+                    rvNotices.visibility = View.GONE
+                    layoutEmpty.visibility = View.VISIBLE
+                } else {
+                    rvNotices.visibility = View.VISIBLE
+                    layoutEmpty.visibility = View.GONE
+                    rvNotices.layoutManager = LinearLayoutManager(requireContext())
+                    rvNotices.adapter = NoticeAdapter(items) { notice ->
+                        val fragment = NoticeDetailFragment().apply {
+                            arguments = Bundle().apply {
+                                putLong(NoticeDetailFragment.ARG_NOTICE_ID, notice.id)
+                                putString(NoticeDetailFragment.ARG_TITLE, notice.title)
+                            }
+                        }
+                        parentFragmentManager.beginTransaction()
+                            .replace(R.id.content_container, fragment)
+                            .addToBackStack(null)
+                            .commit()
                     }
                 }
-                parentFragmentManager.beginTransaction()
-                    .replace(R.id.content_container, fragment)
-                    .addToBackStack(null)
-                    .commit()
+            } catch (_: Exception) {
+                rvNotices.visibility = View.GONE
+                layoutEmpty.visibility = View.VISIBLE
             }
+        }
+    }
+
+    private fun NoticeListDto.toUiModel(): NoticeUiModel {
+        return NoticeUiModel(
+            id = noticeId,
+            title = title,
+            preview = contentPreview,
+            time = formatDate(createdAt),
+            isRead = !isNew,
+            date = formatDate(createdAt),
+            content = ""
+        )
+    }
+
+    private fun formatDate(dateTime: String): String {
+        return try {
+            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            "${parsed.year}. ${parsed.monthValue.toString().padStart(2, '0')}. ${parsed.dayOfMonth.toString().padStart(2, '0')}."
+        } catch (_: Exception) {
+            dateTime.take(10)
         }
     }
 }

--- a/app/src/main/java/com/example/reday/NoticeFragment.kt
+++ b/app/src/main/java/com/example/reday/NoticeFragment.kt
@@ -8,11 +8,11 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.reday.data.remote.NoticeListDto
 import com.example.reday.data.remote.RetrofitClient
 import kotlinx.coroutines.launch
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
+import java.time.ZonedDateTime
 
 class NoticeFragment : Fragment() {
 
@@ -31,39 +31,49 @@ class NoticeFragment : Fragment() {
             parentFragmentManager.popBackStack()
         }
 
+        val swipeRefresh = view.findViewById<SwipeRefreshLayout>(R.id.swipe_refresh)
         val rvNotices = view.findViewById<RecyclerView>(R.id.rv_notices)
         val layoutEmpty = view.findViewById<View>(R.id.layout_empty)
 
-        viewLifecycleOwner.lifecycleScope.launch {
-            try {
-                val response = RetrofitClient.noticeApi.getNotices()
-                val items = response.data.map { it.toUiModel() }
+        swipeRefresh.setColorSchemeResources(R.color.main_200)
 
-                if (items.isEmpty()) {
+        fun loadNotices() {
+            viewLifecycleOwner.lifecycleScope.launch {
+                try {
+                    val response = RetrofitClient.noticeApi.getNotices()
+                    val items = response.data.map { it.toUiModel() }
+
+                    if (items.isEmpty()) {
+                        rvNotices.visibility = View.GONE
+                        layoutEmpty.visibility = View.VISIBLE
+                    } else {
+                        rvNotices.visibility = View.VISIBLE
+                        layoutEmpty.visibility = View.GONE
+                        rvNotices.layoutManager = LinearLayoutManager(requireContext())
+                        rvNotices.adapter = NoticeAdapter(items) { notice ->
+                            val fragment = NoticeDetailFragment().apply {
+                                arguments = Bundle().apply {
+                                    putLong(NoticeDetailFragment.ARG_NOTICE_ID, notice.id)
+                                    putString(NoticeDetailFragment.ARG_TITLE, notice.title)
+                                }
+                            }
+                            parentFragmentManager.beginTransaction()
+                                .replace(R.id.content_container, fragment)
+                                .addToBackStack(null)
+                                .commit()
+                        }
+                    }
+                } catch (_: Exception) {
                     rvNotices.visibility = View.GONE
                     layoutEmpty.visibility = View.VISIBLE
-                } else {
-                    rvNotices.visibility = View.VISIBLE
-                    layoutEmpty.visibility = View.GONE
-                    rvNotices.layoutManager = LinearLayoutManager(requireContext())
-                    rvNotices.adapter = NoticeAdapter(items) { notice ->
-                        val fragment = NoticeDetailFragment().apply {
-                            arguments = Bundle().apply {
-                                putLong(NoticeDetailFragment.ARG_NOTICE_ID, notice.id)
-                                putString(NoticeDetailFragment.ARG_TITLE, notice.title)
-                            }
-                        }
-                        parentFragmentManager.beginTransaction()
-                            .replace(R.id.content_container, fragment)
-                            .addToBackStack(null)
-                            .commit()
-                    }
+                } finally {
+                    swipeRefresh.isRefreshing = false
                 }
-            } catch (_: Exception) {
-                rvNotices.visibility = View.GONE
-                layoutEmpty.visibility = View.VISIBLE
             }
         }
+
+        swipeRefresh.setOnRefreshListener { loadNotices() }
+        loadNotices()
     }
 
     private fun NoticeListDto.toUiModel(): NoticeUiModel {
@@ -80,7 +90,7 @@ class NoticeFragment : Fragment() {
 
     private fun formatDate(dateTime: String): String {
         return try {
-            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            val parsed = ZonedDateTime.parse(dateTime).toLocalDate()
             "${parsed.year}. ${parsed.monthValue.toString().padStart(2, '0')}. ${parsed.dayOfMonth.toString().padStart(2, '0')}."
         } catch (_: Exception) {
             dateTime.take(10)

--- a/app/src/main/java/com/example/reday/NotificationAdapter.kt
+++ b/app/src/main/java/com/example/reday/NotificationAdapter.kt
@@ -62,22 +62,22 @@ class NotificationAdapter(
                 R.drawable.bg_dot_main200
             )
             NotificationType.INQUIRY -> Quad(
-                R.drawable.bg_circle_sub200,
+                if (item.isRead) R.drawable.bg_circle_sub105 else R.drawable.bg_circle_sub200,
                 R.drawable.ic_memo_fragment,
                 R.color.sub_200,
-                R.drawable.bg_circle_sub200
+                R.drawable.bg_dot_sub200
             )
             NotificationType.NOTICE -> Quad(
-                R.drawable.bg_circle_sub105,
+                if (item.isRead) R.drawable.bg_circle_sub105 else R.drawable.bg_circle_sub200,
                 R.drawable.ic_bell,
-                R.color.inactive,
-                null
+                R.color.sub_200,
+                R.drawable.bg_dot_sub200
             )
             NotificationType.REMINDER -> Quad(
-                R.drawable.bg_circle_pink,
+                if (item.isRead) R.drawable.bg_circle_pink else R.drawable.bg_circle_main200,
                 R.drawable.ic_bell,
-                R.color.inactive,
-                null
+                R.color.main_200,
+                R.drawable.bg_dot_main200
             )
         }
 
@@ -100,12 +100,12 @@ class NotificationAdapter(
             }
         }
 
-        // 읽음 상태에 따라 제목 색상 조정
+        // 읽음 상태에 따라 제목/본문 색상 조정
         holder.tvTitle.setTextColor(
-            ContextCompat.getColor(
-                ctx,
-                if (item.isRead) R.color.brown_500 else R.color.brown_700
-            )
+            ContextCompat.getColor(ctx, if (item.isRead) R.color.brown_500 else R.color.brown_700)
+        )
+        holder.tvBody.setTextColor(
+            ContextCompat.getColor(ctx, if (item.isRead) R.color.brown_400 else R.color.brown_500)
         )
     }
 

--- a/app/src/main/java/com/example/reday/NotificationAdapter.kt
+++ b/app/src/main/java/com/example/reday/NotificationAdapter.kt
@@ -19,7 +19,9 @@ data class NotificationUiModel(
     val title: String,
     val body: String,
     val timeLabel: String,
-    val isRead: Boolean
+    val isRead: Boolean,
+    val relatedId: Long? = null,
+    val date: String = ""  // YYYY-MM-DD
 )
 
 class NotificationAdapter(

--- a/app/src/main/java/com/example/reday/NotificationAdapter.kt
+++ b/app/src/main/java/com/example/reday/NotificationAdapter.kt
@@ -23,7 +23,8 @@ data class NotificationUiModel(
 )
 
 class NotificationAdapter(
-    private var items: List<NotificationUiModel>
+    private var items: List<NotificationUiModel>,
+    private val onItemClick: (NotificationUiModel) -> Unit = {}
 ) : RecyclerView.Adapter<NotificationAdapter.ViewHolder>() {
 
     inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
@@ -45,6 +46,8 @@ class NotificationAdapter(
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = items[position]
         val ctx = holder.itemView.context
+
+        holder.card.setOnClickListener { onItemClick(item) }
 
         holder.tvTitle.text = item.title
         holder.tvBody.text = item.body

--- a/app/src/main/java/com/example/reday/NotificationFragment.kt
+++ b/app/src/main/java/com/example/reday/NotificationFragment.kt
@@ -8,14 +8,17 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.example.reday.data.remote.NotificationDto
 import com.example.reday.data.remote.RetrofitClient
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
@@ -31,6 +34,7 @@ class NotificationFragment : Fragment() {
     private lateinit var chipMy: TextView
     private lateinit var btnOnlyUnread: View
     private lateinit var ivOnlyUnreadIcon: ImageView
+    private lateinit var swipeRefresh: SwipeRefreshLayout
 
     private var currentFilter = FilterType.ALL
     private var onlyUnread = false
@@ -60,6 +64,9 @@ class NotificationFragment : Fragment() {
         chipMy = view.findViewById(R.id.chip_my)
         btnOnlyUnread = view.findViewById(R.id.btn_only_unread)
         ivOnlyUnreadIcon = view.findViewById(R.id.iv_only_unread_icon)
+        swipeRefresh = view.findViewById(R.id.swipe_refresh)
+        swipeRefresh.setColorSchemeResources(R.color.main_200)
+        swipeRefresh.setOnRefreshListener { fetchNotifications() }
 
         adapter = NotificationAdapter(emptyList()) { item ->
             if (!item.isRead) markAsRead(item)
@@ -83,6 +90,10 @@ class NotificationFragment : Fragment() {
 
         updateChipUI()
         updateOnlyUnreadUI()
+    }
+
+    override fun onResume() {
+        super.onResume()
         fetchNotifications()
     }
 
@@ -96,10 +107,14 @@ class NotificationFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val response = RetrofitClient.notificationApi.getNotifications(currentFilter.apiCategory)
+                Log.d("NotificationFragment", "API success: ${response.data.size}개")
                 allItems = response.data.map { it.toUiModel() }
                 applyFilter()
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                Log.e("NotificationFragment", "API 실패: ${e.javaClass.simpleName} - ${e.message}")
                 applyFilter()
+            } finally {
+                swipeRefresh.isRefreshing = false
             }
         }
     }
@@ -174,7 +189,7 @@ class NotificationFragment : Fragment() {
 
     private fun formatRelativeTime(dateTime: String): String {
         return try {
-            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            val parsed = ZonedDateTime.parse(dateTime).toLocalDateTime()
             val now = LocalDateTime.now()
             val hours = ChronoUnit.HOURS.between(parsed, now)
             val days = ChronoUnit.DAYS.between(parsed, now)

--- a/app/src/main/java/com/example/reday/NotificationFragment.kt
+++ b/app/src/main/java/com/example/reday/NotificationFragment.kt
@@ -1,5 +1,6 @@
 package com.example.reday
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -70,7 +71,7 @@ class NotificationFragment : Fragment() {
 
         adapter = NotificationAdapter(emptyList()) { item ->
             if (!item.isRead) markAsRead(item)
-            android.widget.Toast.makeText(requireContext(), item.title, android.widget.Toast.LENGTH_SHORT).show()
+            navigateByType(item)
         }
         rvNotifications.layoutManager = LinearLayoutManager(requireContext())
         rvNotifications.adapter = adapter
@@ -135,16 +136,14 @@ class NotificationFragment : Fragment() {
 
     private fun applyFilter() {
         val filtered = if (onlyUnread) allItems.filter { !it.isRead } else allItems
+        layoutFilter.visibility = View.VISIBLE
+        filterDivider.visibility = View.VISIBLE
         if (filtered.isEmpty()) {
             rvNotifications.visibility = View.GONE
             layoutEmpty.visibility = View.VISIBLE
-            layoutFilter.visibility = View.GONE
-            filterDivider.visibility = View.GONE
         } else {
             rvNotifications.visibility = View.VISIBLE
             layoutEmpty.visibility = View.GONE
-            layoutFilter.visibility = View.VISIBLE
-            filterDivider.visibility = View.VISIBLE
         }
         adapter.updateItems(filtered)
     }
@@ -171,6 +170,82 @@ class NotificationFragment : Fragment() {
         ivOnlyUnreadIcon.setImageResource(R.drawable.ic_check_stroke)
     }
 
+    private fun navigateByType(item: NotificationUiModel) {
+        when (item.type) {
+            NotificationType.INQUIRY -> {
+                val fragment = item.relatedId?.let { id ->
+                    InquiryDetailFragment().apply {
+                        arguments = Bundle().apply {
+                            putLong(InquiryDetailFragment.ARG_INQUIRY_ID, id)
+                            putString(InquiryDetailFragment.ARG_TITLE, item.title)
+                        }
+                    }
+                } ?: run {
+                    android.widget.Toast.makeText(
+                        requireContext(),
+                        "문의 목록에서 해당 문의를 확인해주세요",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    InquiryFragment()
+                }
+                navigateToFragment(fragment)
+            }
+            NotificationType.NOTICE -> {
+                val fragment = item.relatedId?.let { id ->
+                    NoticeDetailFragment().apply {
+                        arguments = Bundle().apply {
+                            putLong(NoticeDetailFragment.ARG_NOTICE_ID, id)
+                            putString(NoticeDetailFragment.ARG_TITLE, item.title)
+                        }
+                    }
+                } ?: run {
+                    android.widget.Toast.makeText(
+                        requireContext(),
+                        "공지 목록에서 해당 공지를 확인해주세요",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                    NoticeFragment()
+                }
+                navigateToFragment(fragment)
+            }
+            NotificationType.AI_GENERATE -> {
+                val memoryId = item.relatedId ?: return
+                viewLifecycleOwner.lifecycleScope.launch {
+                    try {
+                        val response = RetrofitClient.springMemoryApi.getMemoryDetail(memoryId)
+                        val date = response.data?.memoryDate ?: return@launch
+                        startActivity(
+                            Intent(requireContext(), MemoryFragmentActivity::class.java).apply {
+                                putExtra(MemoryFragmentActivity.EXTRA_DATE, date)
+                            }
+                        )
+                    } catch (_: Exception) {
+                        navigateToFragment(ArchiveFragment())
+                    }
+                }
+            }
+            NotificationType.REMINDER -> {
+                val parts = item.date.split("-")
+                if (parts.size == 3) {
+                    startActivity(
+                        Intent(requireContext(), AddMemoryActivity::class.java).apply {
+                            putExtra(AddMemoryActivity.EXTRA_YEAR, parts[0].toInt())
+                            putExtra(AddMemoryActivity.EXTRA_MONTH, parts[1].toInt())
+                            putExtra(AddMemoryActivity.EXTRA_DAY, parts[2].toInt())
+                        }
+                    )
+                }
+            }
+        }
+    }
+
+    private fun navigateToFragment(fragment: Fragment) {
+        parentFragmentManager.beginTransaction()
+            .replace(R.id.content_container, fragment)
+            .addToBackStack(null)
+            .commit()
+    }
+
     private fun NotificationDto.toUiModel(): NotificationUiModel {
         val type = when (this.type) {
             "AI_GENERATION" -> NotificationType.AI_GENERATE
@@ -185,7 +260,9 @@ class NotificationFragment : Fragment() {
             title = title,
             body = content,
             timeLabel = formatRelativeTime(createdAt),
-            isRead = isRead
+            isRead = isRead,
+            relatedId = relatedId,
+            date = createdAt.take(10)
         )
     }
 

--- a/app/src/main/java/com/example/reday/NotificationFragment.kt
+++ b/app/src/main/java/com/example/reday/NotificationFragment.kt
@@ -70,6 +70,7 @@ class NotificationFragment : Fragment() {
 
         adapter = NotificationAdapter(emptyList()) { item ->
             if (!item.isRead) markAsRead(item)
+            android.widget.Toast.makeText(requireContext(), item.title, android.widget.Toast.LENGTH_SHORT).show()
         }
         rvNotifications.layoutManager = LinearLayoutManager(requireContext())
         rvNotifications.adapter = adapter
@@ -123,9 +124,9 @@ class NotificationFragment : Fragment() {
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 RetrofitClient.notificationApi.markAsRead(item.id)
-                // 로컬 상태 즉시 반영
                 allItems = allItems.map { if (it.id == item.id) it.copy(isRead = true) else it }
                 applyFilter()
+                (activity as? MainActivity)?.updateNotificationBadge()
             } catch (_: Exception) {
                 // 실패 시 무시 (다음 새로고침 시 서버 상태 반영)
             }
@@ -175,6 +176,7 @@ class NotificationFragment : Fragment() {
             "AI_GENERATION" -> NotificationType.AI_GENERATE
             "DAILY_RECORD" -> NotificationType.REMINDER
             "INQUIRY_ANSWER" -> NotificationType.INQUIRY
+            "NOTICE" -> NotificationType.NOTICE
             else -> NotificationType.NOTICE
         }
         return NotificationUiModel(

--- a/app/src/main/java/com/example/reday/NotificationFragment.kt
+++ b/app/src/main/java/com/example/reday/NotificationFragment.kt
@@ -9,16 +9,36 @@ import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.example.reday.data.remote.NotificationDto
+import com.example.reday.data.remote.RetrofitClient
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 class NotificationFragment : Fragment() {
 
     private lateinit var adapter: NotificationAdapter
+    private lateinit var rvNotifications: RecyclerView
+    private lateinit var layoutEmpty: LinearLayout
+    private lateinit var layoutFilter: LinearLayout
+    private lateinit var filterDivider: View
+    private lateinit var chipAll: TextView
+    private lateinit var chipSystem: TextView
+    private lateinit var chipMy: TextView
+    private lateinit var btnOnlyUnread: View
+    private lateinit var ivOnlyUnreadIcon: ImageView
+
     private var currentFilter = FilterType.ALL
     private var onlyUnread = false
+    private var allItems: List<NotificationUiModel> = emptyList()
 
-    private enum class FilterType { ALL, SYSTEM, MY }
+    private enum class FilterType(val apiCategory: String) {
+        ALL("ALL"), SYSTEM("SYSTEM"), MY("MY")
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -31,103 +51,25 @@ class NotificationFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val rvNotifications = view.findViewById<RecyclerView>(R.id.rv_notifications)
-        val layoutEmpty = view.findViewById<LinearLayout>(R.id.layout_empty)
-        val layoutFilter = view.findViewById<LinearLayout>(R.id.layout_filter)
-        val filterDivider = view.findViewById<View>(R.id.filter_divider)
-        val chipAll = view.findViewById<TextView>(R.id.chip_all)
-        val chipSystem = view.findViewById<TextView>(R.id.chip_system)
-        val chipMy = view.findViewById<TextView>(R.id.chip_my)
-        val btnOnlyUnread = view.findViewById<View>(R.id.btn_only_unread)
-        val ivOnlyUnreadIcon = view.findViewById<ImageView>(R.id.iv_only_unread_icon)
+        rvNotifications = view.findViewById(R.id.rv_notifications)
+        layoutEmpty = view.findViewById(R.id.layout_empty)
+        layoutFilter = view.findViewById(R.id.layout_filter)
+        filterDivider = view.findViewById(R.id.filter_divider)
+        chipAll = view.findViewById(R.id.chip_all)
+        chipSystem = view.findViewById(R.id.chip_system)
+        chipMy = view.findViewById(R.id.chip_my)
+        btnOnlyUnread = view.findViewById(R.id.btn_only_unread)
+        ivOnlyUnreadIcon = view.findViewById(R.id.iv_only_unread_icon)
 
-        val allItems = listOf(
-            NotificationUiModel(1, NotificationType.AI_GENERATE, "AI 생성을 잊으셨나요?",
-                "어제 추가한 기억이 아직 AI 생성되지 않았어요. 지금 완성해보세요!", "1시간 전", false),
-            NotificationUiModel(2, NotificationType.INQUIRY, "문의하신 내용에 답변이 도착...",
-                "\"앱 사용 방법 문의\"에 대한 답변을 확인해보세요", "18시간 전", false),
-            NotificationUiModel(3, NotificationType.NOTICE, "새 공지사항이 등록되었어요",
-                "새로운 기능이 추가되었어요. 지금 바로 써보세요!", "어제", true),
-            NotificationUiModel(4, NotificationType.REMINDER, "오늘의 기억을 남겨보세요",
-                "오늘 하루도 소중한 순간들이 있었을 거예요. 기억을 기록해보세요 📝", "어제", true),
-            NotificationUiModel(5, NotificationType.NOTICE, "Re:Day 정기 점검 안내",
-                "3월 25일 02:00~04:00 정기 점검이 예정되어 있습니다", "2일 전", true),
-            NotificationUiModel(6, NotificationType.AI_GENERATE, "AI 생성을 잊으셨나요?",
-                "3월 15일에 추가한 기억이 아직 완성되지 않았어요", "3일 전", true)
-        )
-
-        adapter = NotificationAdapter(allItems)
+        adapter = NotificationAdapter(emptyList()) { item ->
+            if (!item.isRead) markAsRead(item)
+        }
         rvNotifications.layoutManager = LinearLayoutManager(requireContext())
         rvNotifications.adapter = adapter
 
-        fun filteredItems(): List<NotificationUiModel> {
-            val base = when (currentFilter) {
-                FilterType.ALL -> allItems
-                FilterType.SYSTEM -> allItems.filter {
-                    it.type == NotificationType.NOTICE || it.type == NotificationType.INQUIRY
-                }
-                FilterType.MY -> allItems.filter {
-                    it.type == NotificationType.AI_GENERATE || it.type == NotificationType.REMINDER
-                }
-            }
-            return if (onlyUnread) base.filter { !it.isRead } else base
-        }
-
-        fun applyFilter() {
-            val items = filteredItems()
-            if (items.isEmpty()) {
-                rvNotifications.visibility = View.GONE
-                layoutEmpty.visibility = View.VISIBLE
-                layoutFilter.visibility = View.GONE
-                filterDivider.visibility = View.GONE
-            } else {
-                rvNotifications.visibility = View.VISIBLE
-                layoutEmpty.visibility = View.GONE
-                layoutFilter.visibility = View.VISIBLE
-                filterDivider.visibility = View.VISIBLE
-            }
-            adapter.updateItems(items)
-        }
-
-        fun updateChipUI() {
-            val ctx = requireContext()
-            chipAll.background = ContextCompat.getDrawable(ctx,
-                if (currentFilter == FilterType.ALL) R.drawable.bg_chip_selected else R.drawable.bg_chip_unselected)
-            chipAll.setTextColor(ContextCompat.getColor(ctx, R.color.brown_600))
-
-            chipSystem.background = ContextCompat.getDrawable(ctx,
-                if (currentFilter == FilterType.SYSTEM) R.drawable.bg_chip_selected_system else R.drawable.bg_chip_unselected)
-            chipSystem.setTextColor(ContextCompat.getColor(ctx,
-                if (currentFilter == FilterType.SYSTEM) R.color.brown_50 else R.color.brown_600))
-
-            chipMy.background = ContextCompat.getDrawable(ctx,
-                if (currentFilter == FilterType.MY) R.drawable.bg_chip_selected_my else R.drawable.bg_chip_unselected)
-            chipMy.setTextColor(ContextCompat.getColor(ctx,
-                if (currentFilter == FilterType.MY) R.color.brown_50 else R.color.brown_600))
-        }
-
-        fun updateOnlyUnreadUI() {
-            btnOnlyUnread.alpha = if (onlyUnread) 1.0f else 0.4f
-            ivOnlyUnreadIcon.setImageResource(R.drawable.ic_check_stroke)
-        }
-
-        chipAll.setOnClickListener {
-            currentFilter = FilterType.ALL
-            updateChipUI()
-            applyFilter()
-        }
-
-        chipSystem.setOnClickListener {
-            currentFilter = FilterType.SYSTEM
-            updateChipUI()
-            applyFilter()
-        }
-
-        chipMy.setOnClickListener {
-            currentFilter = FilterType.MY
-            updateChipUI()
-            applyFilter()
-        }
+        chipAll.setOnClickListener { changeFilter(FilterType.ALL) }
+        chipSystem.setOnClickListener { changeFilter(FilterType.SYSTEM) }
+        chipMy.setOnClickListener { changeFilter(FilterType.MY) }
 
         btnOnlyUnread.setOnClickListener {
             onlyUnread = !onlyUnread
@@ -139,8 +81,112 @@ class NotificationFragment : Fragment() {
             parentFragmentManager.popBackStack()
         }
 
-        applyFilter()
         updateChipUI()
         updateOnlyUnreadUI()
+        fetchNotifications()
+    }
+
+    private fun changeFilter(filter: FilterType) {
+        currentFilter = filter
+        updateChipUI()
+        fetchNotifications()
+    }
+
+    private fun fetchNotifications() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.notificationApi.getNotifications(currentFilter.apiCategory)
+                allItems = response.data.map { it.toUiModel() }
+                applyFilter()
+            } catch (_: Exception) {
+                applyFilter()
+            }
+        }
+    }
+
+    private fun markAsRead(item: NotificationUiModel) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                RetrofitClient.notificationApi.markAsRead(item.id)
+                // 로컬 상태 즉시 반영
+                allItems = allItems.map { if (it.id == item.id) it.copy(isRead = true) else it }
+                applyFilter()
+            } catch (_: Exception) {
+                // 실패 시 무시 (다음 새로고침 시 서버 상태 반영)
+            }
+        }
+    }
+
+    private fun applyFilter() {
+        val filtered = if (onlyUnread) allItems.filter { !it.isRead } else allItems
+        if (filtered.isEmpty()) {
+            rvNotifications.visibility = View.GONE
+            layoutEmpty.visibility = View.VISIBLE
+            layoutFilter.visibility = View.GONE
+            filterDivider.visibility = View.GONE
+        } else {
+            rvNotifications.visibility = View.VISIBLE
+            layoutEmpty.visibility = View.GONE
+            layoutFilter.visibility = View.VISIBLE
+            filterDivider.visibility = View.VISIBLE
+        }
+        adapter.updateItems(filtered)
+    }
+
+    private fun updateChipUI() {
+        val ctx = requireContext()
+        chipAll.background = ContextCompat.getDrawable(ctx,
+            if (currentFilter == FilterType.ALL) R.drawable.bg_chip_selected else R.drawable.bg_chip_unselected)
+        chipAll.setTextColor(ContextCompat.getColor(ctx, R.color.brown_600))
+
+        chipSystem.background = ContextCompat.getDrawable(ctx,
+            if (currentFilter == FilterType.SYSTEM) R.drawable.bg_chip_selected_system else R.drawable.bg_chip_unselected)
+        chipSystem.setTextColor(ContextCompat.getColor(ctx,
+            if (currentFilter == FilterType.SYSTEM) R.color.brown_50 else R.color.brown_600))
+
+        chipMy.background = ContextCompat.getDrawable(ctx,
+            if (currentFilter == FilterType.MY) R.drawable.bg_chip_selected_my else R.drawable.bg_chip_unselected)
+        chipMy.setTextColor(ContextCompat.getColor(ctx,
+            if (currentFilter == FilterType.MY) R.color.brown_50 else R.color.brown_600))
+    }
+
+    private fun updateOnlyUnreadUI() {
+        btnOnlyUnread.alpha = if (onlyUnread) 1.0f else 0.4f
+        ivOnlyUnreadIcon.setImageResource(R.drawable.ic_check_stroke)
+    }
+
+    private fun NotificationDto.toUiModel(): NotificationUiModel {
+        val type = when (this.type) {
+            "AI_GENERATION" -> NotificationType.AI_GENERATE
+            "DAILY_RECORD" -> NotificationType.REMINDER
+            "INQUIRY_ANSWER" -> NotificationType.INQUIRY
+            else -> NotificationType.NOTICE
+        }
+        return NotificationUiModel(
+            id = notificationId,
+            type = type,
+            title = title,
+            body = content,
+            timeLabel = formatRelativeTime(createdAt),
+            isRead = isRead
+        )
+    }
+
+    private fun formatRelativeTime(dateTime: String): String {
+        return try {
+            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            val now = LocalDateTime.now()
+            val hours = ChronoUnit.HOURS.between(parsed, now)
+            val days = ChronoUnit.DAYS.between(parsed, now)
+            when {
+                hours < 1 -> "방금 전"
+                hours < 24 -> "${hours}시간 전"
+                days == 1L -> "어제"
+                days < 7 -> "${days}일 전"
+                else -> "${parsed.monthValue}.${parsed.dayOfMonth.toString().padStart(2, '0')}"
+            }
+        } catch (_: Exception) {
+            dateTime.take(10)
+        }
     }
 }

--- a/app/src/main/java/com/example/reday/NotificationSettingsFragment.kt
+++ b/app/src/main/java/com/example/reday/NotificationSettingsFragment.kt
@@ -4,9 +4,22 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.example.reday.data.remote.NotificationSettingsRequest
+import com.example.reday.data.remote.RetrofitClient
+import kotlinx.coroutines.launch
 
 class NotificationSettingsFragment : Fragment() {
+
+    private lateinit var switchPush: SwitchCompat
+    private lateinit var switchUnwritten: SwitchCompat
+    private lateinit var switchAi: SwitchCompat
+
+    // 스위치 변경 이벤트 중복 호출 방지
+    private var isLoading = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -19,8 +32,56 @@ class NotificationSettingsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        switchPush = view.findViewById(R.id.switch_push)
+        switchUnwritten = view.findViewById(R.id.switch_unwritten)
+        switchAi = view.findViewById(R.id.switch_ai)
+
         view.findViewById<View>(R.id.btn_back).setOnClickListener {
             parentFragmentManager.popBackStack()
+        }
+
+        loadSettings()
+        setupSwitchListeners()
+    }
+
+    private fun loadSettings() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.notificationApi.getSettings()
+                val data = response.data
+                isLoading = true
+                switchPush.isChecked = data.pushEnabled
+                switchUnwritten.isChecked = data.dailyRecordEnabled
+                switchAi.isChecked = data.aiGenerationEnabled
+                isLoading = false
+            } catch (_: Exception) {
+                isLoading = false
+            }
+        }
+    }
+
+    private fun setupSwitchListeners() {
+        val listener = { _: android.widget.CompoundButton, _: Boolean ->
+            if (!isLoading) saveSettings()
+        }
+        switchPush.setOnCheckedChangeListener(listener)
+        switchUnwritten.setOnCheckedChangeListener(listener)
+        switchAi.setOnCheckedChangeListener(listener)
+    }
+
+    private fun saveSettings() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                RetrofitClient.notificationApi.updateSettings(
+                    NotificationSettingsRequest(
+                        pushEnabled = switchPush.isChecked,
+                        dailyRecordEnabled = switchUnwritten.isChecked,
+                        aiGenerationEnabled = switchAi.isChecked
+                    )
+                )
+            } catch (_: Exception) {
+                Toast.makeText(requireContext(), "설정 저장에 실패했습니다.", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/reday/ProfileFragment.kt
+++ b/app/src/main/java/com/example/reday/ProfileFragment.kt
@@ -5,14 +5,25 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import com.example.reday.data.remote.RetrofitClient
+import com.example.reday.data.remote.UpdateNameRequest
 import com.example.reday.utils.TokenManager
 import com.google.android.material.card.MaterialCardView
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class ProfileFragment : Fragment() {
+
+    private lateinit var tvUserName: TextView
+    private lateinit var tvUserEmail: TextView
+    private lateinit var tvUserJoined: TextView
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -25,14 +36,18 @@ class ProfileFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // 유저 정보 바인딩
-        val name = TokenManager.getUserName(requireContext())
-        val email = TokenManager.getUserEmail(requireContext())
+        tvUserName = view.findViewById(R.id.tv_user_name)
+        tvUserEmail = view.findViewById(R.id.tv_user_email)
+        tvUserJoined = view.findViewById(R.id.tv_user_joined)
 
-        view.findViewById<TextView>(R.id.tv_user_name).text = name.ifBlank { "이름 없음" }
-        view.findViewById<TextView>(R.id.tv_user_email).text = email.ifBlank { "-" }
-        view.findViewById<TextView>(R.id.tv_user_joined).visibility =
-            if (name.isBlank() && email.isBlank()) android.view.View.GONE else android.view.View.VISIBLE
+        // 로컬 캐시로 먼저 표시 후 API로 갱신
+        bindLocalUserInfo()
+        loadUserProfile()
+
+        // 이름 편집
+        view.findViewById<View>(R.id.btn_edit_name).setOnClickListener {
+            showEditNameDialog()
+        }
 
         // 뒤로 가기
         view.findViewById<View>(R.id.btn_back).setOnClickListener {
@@ -68,12 +83,7 @@ class ProfileFragment : Fragment() {
             AlertDialog.Builder(requireContext())
                 .setTitle("로그아웃")
                 .setMessage("정말 로그아웃 하시겠어요?")
-                .setPositiveButton("로그아웃") { _, _ ->
-                    TokenManager.clearToken(requireContext())
-                    val intent = Intent(requireContext(), LoginActivity::class.java)
-                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    startActivity(intent)
-                }
+                .setPositiveButton("로그아웃") { _, _ -> performLogout() }
                 .setNegativeButton("취소", null)
                 .show()
         }
@@ -83,9 +93,7 @@ class ProfileFragment : Fragment() {
             AlertDialog.Builder(requireContext())
                 .setTitle("회원 탈퇴")
                 .setMessage("탈퇴하면 모든 기억과 기록이 삭제됩니다.\n정말 탈퇴하시겠어요?")
-                .setPositiveButton("탈퇴") { _, _ ->
-                    Toast.makeText(requireContext(), "회원 탈퇴 준비 중입니다.", Toast.LENGTH_SHORT).show()
-                }
+                .setPositiveButton("탈퇴") { _, _ -> performWithdraw() }
                 .setNegativeButton("취소", null)
                 .show()
         }
@@ -104,6 +112,107 @@ class ProfileFragment : Fragment() {
                 .replace(R.id.content_container, TermsFragment.newPrivacy())
                 .addToBackStack(null)
                 .commit()
+        }
+    }
+
+    private fun bindLocalUserInfo() {
+        val name = TokenManager.getUserName(requireContext())
+        val email = TokenManager.getUserEmail(requireContext())
+        tvUserName.text = name.ifBlank { "이름 없음" }
+        tvUserEmail.text = email.ifBlank { "-" }
+        tvUserJoined.visibility = View.GONE
+    }
+
+    private fun loadUserProfile() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.userApi.getMyProfile()
+                val data = response.data
+                tvUserName.text = data.name
+                tvUserEmail.text = data.email
+                tvUserJoined.text = "가입일: ${formatDate(data.createdAt)}"
+                tvUserJoined.visibility = View.VISIBLE
+                TokenManager.saveUserName(requireContext(), data.name)
+                TokenManager.saveUserEmail(requireContext(), data.email)
+            } catch (_: Exception) {
+                // 로컬 캐시 유지, 별도 에러 표시 없음
+            }
+        }
+    }
+
+    private fun showEditNameDialog() {
+        val input = EditText(requireContext()).apply {
+            setText(tvUserName.text)
+            hint = "새 이름을 입력해주세요"
+            setPadding(48, 32, 48, 32)
+        }
+        AlertDialog.Builder(requireContext())
+            .setTitle("이름 변경")
+            .setView(input)
+            .setPositiveButton("저장") { _, _ ->
+                val newName = input.text.toString().trim()
+                if (newName.isBlank()) {
+                    Toast.makeText(requireContext(), "이름을 입력해주세요.", Toast.LENGTH_SHORT).show()
+                } else {
+                    updateName(newName)
+                }
+            }
+            .setNegativeButton("취소", null)
+            .show()
+    }
+
+    private fun updateName(newName: String) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.userApi.updateMyProfile(UpdateNameRequest(newName))
+                tvUserName.text = response.data.name
+                TokenManager.saveUserName(requireContext(), response.data.name)
+                Toast.makeText(requireContext(), "이름이 변경되었습니다.", Toast.LENGTH_SHORT).show()
+            } catch (_: Exception) {
+                Toast.makeText(requireContext(), "이름 변경에 실패했습니다.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun formatDate(dateTime: String): String {
+        return try {
+            val parsed = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            "${parsed.year}.${parsed.monthValue.toString().padStart(2, '0')}.${parsed.dayOfMonth.toString().padStart(2, '0')}"
+        } catch (_: Exception) {
+            dateTime.take(10).replace("-", ".")
+        }
+    }
+
+    private fun performLogout() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                RetrofitClient.authApi.logout()
+            } catch (_: Exception) {
+                // 서버 오류와 무관하게 로컬 토큰 삭제 후 이동
+            } finally {
+                TokenManager.clearToken(requireContext())
+                val intent = Intent(requireContext(), LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                startActivity(intent)
+            }
+        }
+    }
+
+    private fun performWithdraw() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            try {
+                val response = RetrofitClient.authApi.withdraw()
+                if (response.isSuccessful) {
+                    TokenManager.clearToken(requireContext())
+                    val intent = Intent(requireContext(), LoginActivity::class.java)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    startActivity(intent)
+                } else {
+                    Toast.makeText(requireContext(), "탈퇴 처리에 실패했습니다. 다시 시도해주세요.", Toast.LENGTH_SHORT).show()
+                }
+            } catch (_: Exception) {
+                Toast.makeText(requireContext(), "네트워크 오류가 발생했습니다.", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/reday/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/AuthApiService.kt
@@ -1,6 +1,8 @@
 package com.example.reday.data.remote
 
+import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.POST
 
 data class SignupRequest(
@@ -48,4 +50,10 @@ interface AuthApiService {
 
     @POST("api/auth/login")
     suspend fun login(@Body request: LoginRequest): LoginResponse
+
+    @POST("api/auth/logout")
+    suspend fun logout(): Response<Unit>
+
+    @DELETE("api/auth/withdraw")
+    suspend fun withdraw(): Response<Unit>
 }

--- a/app/src/main/java/com/example/reday/data/remote/InquiryApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/InquiryApiService.kt
@@ -1,0 +1,65 @@
+package com.example.reday.data.remote
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+data class InquiryListDto(
+    val inquiryId: Long,
+    val title: String,
+    val contentPreview: String,
+    val status: String,
+    val replyContent: String?,
+    val createdAt: String
+)
+
+data class InquiryListResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: List<InquiryListDto>
+)
+
+data class InquiryDetailDto(
+    val inquiryId: Long,
+    val title: String,
+    val content: String,
+    val status: String,
+    val replyContent: String?,
+    val repliedAt: String?,
+    val createdAt: String
+)
+
+data class InquiryDetailResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: InquiryDetailDto
+)
+
+data class InquiryCreateRequest(
+    val title: String,
+    val content: String
+)
+
+data class InquiryCreateData(val inquiryId: Long)
+
+data class InquiryCreateResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: InquiryCreateData
+)
+
+interface InquiryApiService {
+
+    @GET("api/inquiries")
+    suspend fun getInquiries(): InquiryListResponse
+
+    @POST("api/inquiries")
+    suspend fun createInquiry(@Body request: InquiryCreateRequest): InquiryCreateResponse
+
+    @GET("api/inquiries/{inquiryId}")
+    suspend fun getInquiryDetail(@Path("inquiryId") inquiryId: Long): InquiryDetailResponse
+}

--- a/app/src/main/java/com/example/reday/data/remote/NoticeApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/NoticeApiService.kt
@@ -1,0 +1,42 @@
+package com.example.reday.data.remote
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+data class NoticeListDto(
+    val noticeId: Long,
+    val title: String,
+    val contentPreview: String,
+    val isNew: Boolean,
+    val createdAt: String
+)
+
+data class NoticeListResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: List<NoticeListDto>
+)
+
+data class NoticeDetailDto(
+    val noticeId: Long,
+    val title: String,
+    val content: String,
+    val createdAt: String
+)
+
+data class NoticeDetailResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: NoticeDetailDto
+)
+
+interface NoticeApiService {
+
+    @GET("api/notices")
+    suspend fun getNotices(): NoticeListResponse
+
+    @GET("api/notices/{noticeId}")
+    suspend fun getNoticeDetail(@Path("noticeId") noticeId: Long): NoticeDetailResponse
+}

--- a/app/src/main/java/com/example/reday/data/remote/NotificationApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/NotificationApiService.kt
@@ -1,0 +1,66 @@
+package com.example.reday.data.remote
+
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.PUT
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+data class NotificationSettingsData(
+    val pushEnabled: Boolean,
+    val dailyRecordEnabled: Boolean,
+    val aiGenerationEnabled: Boolean
+)
+
+data class NotificationSettingsResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: NotificationSettingsData
+)
+
+data class NotificationSettingsRequest(
+    val pushEnabled: Boolean,
+    val dailyRecordEnabled: Boolean,
+    val aiGenerationEnabled: Boolean
+)
+
+data class NotificationDto(
+    val notificationId: Long,
+    val type: String,
+    val title: String,
+    val content: String,
+    val isRead: Boolean,
+    val createdAt: String
+)
+
+data class NotificationListResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: List<NotificationDto>
+)
+
+data class ReadNotificationResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: Any?
+)
+
+interface NotificationApiService {
+
+    @GET("api/notifications/settings")
+    suspend fun getSettings(): NotificationSettingsResponse
+
+    @PUT("api/notifications/settings")
+    suspend fun updateSettings(@Body request: NotificationSettingsRequest): NotificationSettingsResponse
+
+    @GET("api/notifications")
+    suspend fun getNotifications(@Query("category") category: String = "ALL"): NotificationListResponse
+
+    @PATCH("api/notifications/{notificationId}/read")
+    suspend fun markAsRead(@Path("notificationId") notificationId: Long): Response<ReadNotificationResponse>
+}

--- a/app/src/main/java/com/example/reday/data/remote/NotificationApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/NotificationApiService.kt
@@ -33,7 +33,8 @@ data class NotificationDto(
     val title: String,
     val content: String,
     val isRead: Boolean,
-    val createdAt: String
+    val createdAt: String,
+    val relatedId: Long? = null
 )
 
 data class NotificationListResponse(

--- a/app/src/main/java/com/example/reday/data/remote/RetrofitClient.kt
+++ b/app/src/main/java/com/example/reday/data/remote/RetrofitClient.kt
@@ -65,6 +65,22 @@ object RetrofitClient {
         retrofit.create(AuthApiService::class.java)
     }
 
+    val userApi: UserApiService by lazy {
+        retrofit.create(UserApiService::class.java)
+    }
+
+    val notificationApi: NotificationApiService by lazy {
+        retrofit.create(NotificationApiService::class.java)
+    }
+
+    val noticeApi: NoticeApiService by lazy {
+        retrofit.create(NoticeApiService::class.java)
+    }
+
+    val inquiryApi: InquiryApiService by lazy {
+        retrofit.create(InquiryApiService::class.java)
+    }
+
     val recordApi: RecordApiService by lazy {
         retrofit.create(RecordApiService::class.java)
     }

--- a/app/src/main/java/com/example/reday/data/remote/UserApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/UserApiService.kt
@@ -1,0 +1,31 @@
+package com.example.reday.data.remote
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.PUT
+
+data class UserProfileData(
+    val userId: Long,
+    val name: String,
+    val email: String,
+    val createdAt: String
+)
+
+data class UserProfileResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: UserProfileData
+)
+
+data class UpdateNameRequest(
+    val name: String
+)
+
+interface UserApiService {
+    @GET("api/users/me")
+    suspend fun getMyProfile(): UserProfileResponse
+
+    @PUT("api/users/me")
+    suspend fun updateMyProfile(@Body request: UpdateNameRequest): UserProfileResponse
+}

--- a/app/src/main/res/drawable/bg_dot_red.xml
+++ b/app/src/main/res/drawable/bg_dot_red.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/red" />
+</shape>

--- a/app/src/main/res/drawable/bg_dot_red.xml
+++ b/app/src/main/res/drawable/bg_dot_red.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid android:color="@color/red" />
-</shape>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="oval">
+            <solid android:color="@color/main_100" />
+        </shape>
+    </item>
+    <item
+        android:top="2dp"
+        android:bottom="2dp"
+        android:left="2dp"
+        android:right="2dp">
+        <shape android:shape="oval">
+            <solid android:color="@color/main_200" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/bg_dot_sub200.xml
+++ b/app/src/main/res/drawable/bg_dot_sub200.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/sub_200" />
+</shape>

--- a/app/src/main/res/drawable/ic_pencil.xml
+++ b/app/src/main/res/drawable/ic_pencil.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:strokeColor="#000000"
+        android:strokeWidth="1.8"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M16.475,5.408l2.117,2.117M3,17.25V21h3.75L17.81,9.94a1.5,1.5 0,0 0,0 -2.121l-1.629,-1.629a1.5,1.5 0,0 0,-2.121 0L3,17.25z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,10 +68,11 @@
 
             <View
                 android:id="@+id/badge_notification"
-                android:layout_width="8dp"
-                android:layout_height="8dp"
+                android:layout_width="10dp"
+                android:layout_height="10dp"
                 android:layout_gravity="top|end"
-                android:layout_margin="4dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="8dp"
                 android:background="@drawable/bg_dot_red"
                 android:visibility="gone" />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -46,20 +46,36 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent" />
 
-        <ImageButton
-            android:id="@+id/btn_notification"
+        <FrameLayout
+            android:id="@+id/frame_notification"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:background="@drawable/bg_icon_button"
-            android:src="@drawable/ic_bell"
-            app:tint="@color/brown_700"
-            android:scaleType="fitCenter"
-            android:padding="8dp"
-            android:contentDescription="알림"
             android:layout_marginEnd="6dp"
             app:layout_constraintEnd_toStartOf="@id/btn_profile"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <ImageButton
+                android:id="@+id/btn_notification"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/bg_icon_button"
+                android:src="@drawable/ic_bell"
+                app:tint="@color/brown_700"
+                android:scaleType="fitCenter"
+                android:padding="8dp"
+                android:contentDescription="알림" />
+
+            <View
+                android:id="@+id/badge_notification"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                android:layout_gravity="top|end"
+                android:layout_margin="4dp"
+                android:background="@drawable/bg_dot_red"
+                android:visibility="gone" />
+
+        </FrameLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_inquiry.xml
+++ b/app/src/main/res/layout/fragment_inquiry.xml
@@ -48,46 +48,58 @@
         android:layout_height="1dp"
         android:background="@color/inactive" />
 
-    <!-- 목록 -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_inquiries"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:padding="20dp"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        android:layout_weight="1">
 
-    <!-- 빈 상태 -->
-    <LinearLayout
-        android:id="@+id/layout_empty"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:padding="20dp"
-        android:visibility="gone">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="문의 내역이 없어요"
-            android:textColor="@color/brown_700"
-            android:textSize="20sp"
-            android:textStyle="bold" />
+            <!-- 목록 -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_inquiries"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="20dp"
+                android:clipToPadding="false"
+                android:visibility="gone" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="궁금한 점이 있으면\n아래 버튼으로 문의해주세요"
-            android:textColor="@color/brown_500"
-            android:textSize="14sp"
-            android:gravity="center"
-            android:lineSpacingExtra="2dp" />
+            <!-- 빈 상태 -->
+            <LinearLayout
+                android:id="@+id/layout_empty"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="20dp"
+                android:visibility="gone">
 
-    </LinearLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="문의 내역이 없어요"
+                    android:textColor="@color/brown_700"
+                    android:textSize="20sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="궁금한 점이 있으면\n아래 버튼으로 문의해주세요"
+                    android:textColor="@color/brown_500"
+                    android:textSize="14sp"
+                    android:gravity="center"
+                    android:lineSpacingExtra="2dp" />
+
+            </LinearLayout>
+
+        </FrameLayout>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
     <!-- 하단 문의하기 버튼 -->
     <LinearLayout

--- a/app/src/main/res/layout/fragment_inquiry_detail.xml
+++ b/app/src/main/res/layout/fragment_inquiry_detail.xml
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/brown_100">
+
+    <!-- 툴바 -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/brown_50"
+        android:paddingHorizontal="10dp"
+        android:paddingVertical="10dp">
+
+        <ImageButton
+            android:id="@+id/btn_back"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/ic_chevron_left"
+            android:scaleType="fitCenter"
+            android:padding="8dp"
+            android:contentDescription="뒤로"
+            app:tint="@color/brown_700"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="문의 상세"
+            android:textColor="@color/brown_700"
+            android:textSize="20sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- 툴바 하단 구분선 -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/inactive" />
+
+    <!-- 바디 -->
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true"
+        android:padding="20dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <!-- 문의 내용 카드 -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:cardBackgroundColor="@color/brown_50"
+                app:cardCornerRadius="20dp"
+                app:cardElevation="0dp"
+                app:strokeColor="@color/inactive"
+                app:strokeWidth="1dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <!-- 날짜 + 제목 -->
+                    <TextView
+                        android:id="@+id/tv_inquiry_date"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/brown_400"
+                        android:textSize="12sp" />
+
+                    <TextView
+                        android:id="@+id/tv_inquiry_title"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="6dp"
+                        android:textColor="@color/brown_700"
+                        android:textSize="17sp"
+                        android:textStyle="bold" />
+
+                    <!-- 구분선 -->
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="14dp"
+                        android:layout_marginBottom="14dp"
+                        android:background="@color/inactive" />
+
+                    <!-- 문의 본문 -->
+                    <TextView
+                        android:id="@+id/tv_inquiry_content"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/brown_700"
+                        android:textSize="14sp"
+                        android:lineSpacingMultiplier="1.6" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <!-- 답변 대기 -->
+            <LinearLayout
+                android:id="@+id/layout_answer_pending"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="24dp"
+                android:visibility="gone">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="답변 대기 중입니다"
+                    android:textColor="@color/brown_400"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="통상 7일 내에 답변 드립니다."
+                    android:textColor="@color/brown_300"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
+
+            <!-- 답변 완료 -->
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/layout_answer_received"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:visibility="gone"
+                app:cardBackgroundColor="@color/brown_50"
+                app:cardCornerRadius="20dp"
+                app:cardElevation="0dp"
+                app:strokeColor="@color/inactive"
+                app:strokeWidth="1dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:padding="20dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical">
+
+                        <TextView
+                            android:id="@+id/tv_answer_author"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Re:Day 팀"
+                            android:textColor="@color/main_200"
+                            android:textSize="14sp"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/tv_answer_date"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:textColor="@color/brown_400"
+                            android:textSize="12sp" />
+
+                    </LinearLayout>
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="12dp"
+                        android:layout_marginBottom="12dp"
+                        android:background="@color/inactive" />
+
+                    <TextView
+                        android:id="@+id/tv_answer_content"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="@color/brown_700"
+                        android:textSize="14sp"
+                        android:lineSpacingMultiplier="1.6" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_notice.xml
+++ b/app/src/main/res/layout/fragment_notice.xml
@@ -48,45 +48,57 @@
         android:layout_height="1dp"
         android:background="@color/inactive" />
 
-    <!-- 목록 -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_notices"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:padding="20dp"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        android:layout_weight="1">
 
-    <!-- 빈 상태 -->
-    <LinearLayout
-        android:id="@+id/layout_empty"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:padding="20dp"
-        android:visibility="gone">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="공지사항이 없어요"
-            android:textColor="@color/brown_700"
-            android:textSize="20sp"
-            android:textStyle="bold" />
+            <!-- 목록 -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_notices"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="20dp"
+                android:clipToPadding="false"
+                android:visibility="gone" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="새로운 공지가 오면\n여기에서 확인할 수 있어요"
-            android:textColor="@color/brown_500"
-            android:textSize="14sp"
-            android:gravity="center"
-            android:lineSpacingExtra="2dp" />
+            <!-- 빈 상태 -->
+            <LinearLayout
+                android:id="@+id/layout_empty"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="20dp"
+                android:visibility="gone">
 
-    </LinearLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="공지사항이 없어요"
+                    android:textColor="@color/brown_700"
+                    android:textSize="20sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="새로운 공지가 오면\n여기에서 확인할 수 있어요"
+                    android:textColor="@color/brown_500"
+                    android:textSize="14sp"
+                    android:gravity="center"
+                    android:lineSpacingExtra="2dp" />
+
+            </LinearLayout>
+
+        </FrameLayout>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_notification.xml
+++ b/app/src/main/res/layout/fragment_notification.xml
@@ -134,45 +134,57 @@
         android:background="@color/inactive"
         android:visibility="gone" />
 
-    <!-- 알림 목록 -->
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rv_notifications"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:padding="20dp"
-        android:clipToPadding="false"
-        android:visibility="gone" />
+        android:layout_weight="1">
 
-    <!-- 빈 상태 -->
-    <LinearLayout
-        android:id="@+id/layout_empty"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:padding="20dp"
-        android:visibility="visible">
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="알람이 없어요"
-            android:textColor="@color/brown_700"
-            android:textSize="20sp"
-            android:textStyle="bold" />
+            <!-- 알림 목록 -->
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_notifications"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:padding="20dp"
+                android:clipToPadding="false"
+                android:visibility="gone" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp"
-            android:text="새로운 알림이 오면\n여기에서 확인할 수 있어요"
-            android:textColor="@color/brown_500"
-            android:textSize="14sp"
-            android:gravity="center"
-            android:lineSpacingExtra="2dp" />
+            <!-- 빈 상태 -->
+            <LinearLayout
+                android:id="@+id/layout_empty"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="20dp"
+                android:visibility="visible">
 
-    </LinearLayout>
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="알람이 없어요"
+                    android:textColor="@color/brown_700"
+                    android:textSize="20sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:text="새로운 알림이 오면\n여기에서 확인할 수 있어요"
+                    android:textColor="@color/brown_500"
+                    android:textSize="14sp"
+                    android:gravity="center"
+                    android:lineSpacingExtra="2dp" />
+
+            </LinearLayout>
+
+        </FrameLayout>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -80,40 +80,57 @@
                 app:strokeColor="@color/inactive"
                 app:strokeWidth="1dp">
 
-                <LinearLayout
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    xmlns:app="http://schemas.android.com/apk/res-auto"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
                     android:padding="20dp">
 
                     <TextView
                         android:id="@+id/tv_user_name"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:text="이름"
                         android:textColor="@color/brown_700"
                         android:textSize="20sp"
-                        android:textStyle="bold" />
+                        android:textStyle="bold"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/btn_edit_name"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <ImageButton
+                        android:id="@+id/btn_edit_name"
+                        android:layout_width="32dp"
+                        android:layout_height="32dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:src="@drawable/ic_pencil"
+                        android:scaleType="fitCenter"
+                        android:padding="6dp"
+                        android:contentDescription="이름 편집"
+                        app:tint="@color/brown_400"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
 
                     <TextView
                         android:id="@+id/tv_user_email"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="4dp"
-                        android:text="이메일"
                         android:textColor="@color/brown_700"
-                        android:textSize="14sp" />
+                        android:textSize="14sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_user_name" />
 
                     <TextView
                         android:id="@+id/tv_user_joined"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
-                        android:text="가입일"
-                        android:textColor="@color/brown_700"
-                        android:textSize="12sp" />
+                        android:textColor="@color/brown_500"
+                        android:textSize="12sp"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/tv_user_email" />
 
-                </LinearLayout>
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
             </com.google.android.material.card.MaterialCardView>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 
 mpandroidchart = { group = "com.github.PhilJay", name = "MPAndroidChart", version = "v3.1.0" }
 glide = { group = "com.github.bumptech.glide", name = "glide", version = "4.16.0" }
+androidx-swiperefreshlayout = { group = "androidx.swiperefreshlayout", name = "swiperefreshlayout", version = "1.1.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# 📌 Pull Request Title
feat: 알림 읽음/미읽음 UI, 클릭 네비게이션, 홈 배지 구현 

---

# ✨ 작업 내용 (What)
- 알림 아이템 읽음/안읽음 시각적 상태 수정 (카드 테두리, 아이콘 배경, 도트, 텍스트 색상)
  - 알림 클릭 시 타입별 화면 이동 구현
    - AI_GENERATION → 해당 날짜 기억 상세 화면 (메모리 API 호출 후 이동)
    - DAILY_RECORD → 알림 날짜 기준 기억 조각 추가 화면
    - INQUIRY_ANSWER → 문의 상세 화면 (relatedId 없으면 목록 + 토스트)
    - NOTICE → 공지 상세 화면 (relatedId 없으면 목록 + 토스트)
  - 알림 클릭 시 읽음 처리 API 호출 (PATCH /api/notifications/{id}/read)
  - 알림 없을 때도 필터 칩(전체 / 시스템 / 내 알림) 항상 표시
  - 홈 화면 알림 아이콘에 미읽은 알림 배지 추가 (앱 진입 및 알림 화면 복귀 시 갱신)

---

# 🧩 변경 사항 (Changes)
  - NotificationAdapter.kt
    - NotificationUiModel에 relatedId, date 필드 추가
    - 4가지 타입(AI_GENERATE, INQUIRY, NOTICE, REMINDER) 읽음/안읽음 상태별 아이콘 배경, 카드
   테두리, 도트, 텍스트 색상 적용
  - NotificationFragment.kt
    - navigateByType() 구현 — 타입별 Fragment/Activity 이동 로직
    - toUiModel() — relatedId, date(createdAt.take(10)) 매핑 추가
    - applyFilter() — 리스트가 비어도 필터 레이아웃 VISIBLE 유지
    - markAsRead() — 클릭 시 읽음 처리 후 배지 갱신
  - NotificationApiService.kt
    - NotificationDto에 relatedId: Long? 필드 추가
  - MainActivity.kt
    - updateNotificationBadge() 추가 — 미읽은 알림 존재 시 배지 표시
    - 앱 시작 및 백스택 변경 시 배지 갱신 호출
  - activity_main.xml
    - btn_notification을 FrameLayout으로 감싸고 badge_notification View 추가
  - bg_dot_red.xml (신규)
    - main_100 외곽 + main_200 내부 레이어리스트 배지 drawable

---

# 📸 스크린샷 (UI 변경 시 필수)
UI가 변경되었거나 추가된 경우 반드시 이미지 첨부

예:  
| Before | After |  
|--------|--------|  
| (이미지) | (이미지) |

---

# 🧪 테스트 방법 (How to Test)
  - 앱 실행 → 미읽은 알림 있을 때 홈 화면 알림 벨 아이콘에 배지 확인
  - 알림 화면 진입 → 알림 아이템 읽음/안읽음 시각적 상태 확인
  - 각 타입별 알림 클릭 → 해당 화면으로 정상 이동 확인
  - 알림 클릭 후 다시 알림 화면 진입 → 읽음 처리된 스타일로 변경 확인
  - 모든 알림 읽음 처리 후 홈 복귀 → 배지 사라짐 확인
  - 필터(전체/시스템/내 알림) 변경 시 알림 없어도 필터 칩 표시 확인


---

# ✔ 체크리스트 (Checklist)
- [ ] 정상적으로 빌드됨
- [ ] Figma 디자인과 일치
- [ ] 불필요한 코드/주석 제거
- [ ] 브랜치 규칙 준수(feat/fix/design/refactor)
- [ ] 커밋 규칙 준수
- [ ] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: closed #35 
