### PR TITLE
fix: 회원가입 아이디·비밀번호 유효성 검사 완화

### DIFF
--- a/app/src/main/java/com/example/reday/SignupActivity.kt
+++ b/app/src/main/java/com/example/reday/SignupActivity.kt
@@ -6,7 +6,6 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
-import android.util.Patterns
 import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
@@ -182,12 +181,12 @@ class SignupActivity : AppCompatActivity() {
             val password = etPassword.text.toString()
             val passwordConfirm = etPasswordConfirm.text.toString()
 
-            if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
-                etEmail.error = "올바른 이메일 형식을 입력해주세요."
+            if (email.length < 6) {
+                etEmail.error = "아이디는 6자 이상이어야 합니다."
                 return@setOnClickListener
             }
-            if (password.length < 8) {
-                etPassword.error = "비밀번호는 8자 이상이어야 합니다."
+            if (password.length < 6) {
+                etPassword.error = "비밀번호는 6자 이상이어야 합니다."
                 return@setOnClickListener
             }
             if (password != passwordConfirm) {


### PR DESCRIPTION
# 📌 Pull Request Title
fix: 회원가입 아이디·비밀번호 유효성 검사 완화

---

# ✨ 작업 내용 (What)
  - 회원가입 아이디 유효성 검사: 이메일 형식 제거 → 6자 이상 일반 문자열 허용
  - 회원가입 비밀번호 유효성 검사: 8자 이상 → 6자 이상으로 완화

---

# 🧩 변경 사항 (Changes)
  - SignupActivity.kt
    - 이메일 형식 검사(Patterns.EMAIL_ADDRESS) 제거, 6자 이상 길이 검사로 교체
    - 비밀번호 최소 길이 조건 8 → 6으로 수정
    - 미사용 android.util.Patterns import 제거
  - 서버 정책 변경에 따른 클라이언트 동기화 작업 (기존 이메일 형식 계정 로그인에는 영향 없음)

---

# 📸 스크린샷 (UI 변경 시 필수)
UI가 변경되었거나 추가된 경우 반드시 이미지 첨부

예:  
| Before | After |  
|--------|--------|  
| (이미지) | (이미지) |

---

# 🧪 테스트 방법 (How to Test)
  - 앱 실행 → 회원가입 이동
  - 아이디에 testid, user01 등 이메일 형식이 아닌 6자 이상 문자열 입력 시 정상 가입 진행 확인
  - 비밀번호 6자 입력 시 오류 없이 가입 진행 확인
  - 비밀번호 5자 이하 입력 시 "비밀번호는 6자 이상이어야 합니다." 에러 메시지 표시 확인
  - 기존 이메일 형식 계정으로 로그인 정상 동작 확인

---

# ✔ 체크리스트 (Checklist)
- [X] 정상적으로 빌드됨
- [X] Figma 디자인과 일치
- [X] 불필요한 코드/주석 제거
- [X] 브랜치 규칙 준수(feat/fix/design/refactor)
- [X] 커밋 규칙 준수
- [X] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: closed #40 
