### PR TITLE
feat: 회원가입 아이디 중복확인 기능 추가 및 캘린더 버그 수정 

### DIFF
--- a/app/src/main/java/com/example/reday/CalendarFragment.kt
+++ b/app/src/main/java/com/example/reday/CalendarFragment.kt
@@ -124,7 +124,6 @@ class CalendarFragment : Fragment() {
             loadAndRender()
         }
 
-        loadAndRender()
     }
 
     override fun onResume() {
@@ -134,9 +133,13 @@ class CalendarFragment : Fragment() {
 
     private fun loadAndRender() {
         viewLifecycleOwner.lifecycleScope.launch {
-            val fragmentDays = repository.getRecordDatesByMonth(currentYear, currentMonth + 1)
-            memoryDays = memoryRepository.getMemoryDatesByMonth(currentYear, currentMonth + 1)
-            recordingDays = fragmentDays - memoryDays
+            try {
+                val fragmentDays = repository.getRecordDatesByMonth(currentYear, currentMonth + 1)
+                memoryDays = memoryRepository.getMemoryDatesByMonth(currentYear, currentMonth + 1)
+                recordingDays = fragmentDays - memoryDays
+            } catch (e: Exception) {
+                // 데이터 로딩 실패 시에도 캘린더는 렌더링
+            }
             renderCalendar()
         }
     }

--- a/app/src/main/java/com/example/reday/SignupActivity.kt
+++ b/app/src/main/java/com/example/reday/SignupActivity.kt
@@ -37,16 +37,21 @@ class SignupActivity : AppCompatActivity() {
     private lateinit var cbTerms: CheckBox
     private lateinit var cbPrivacy: CheckBox
     private lateinit var btnSignup: MaterialButton
+    private lateinit var btnCheckDuplicate: MaterialButton
+    private lateinit var tvDuplicateStatus: TextView
     private lateinit var tvLogin: TextView
     private lateinit var progressBar: ProgressBar
 
     private var isPwdVisible = false
     private var isPwdConfirmVisible = false
+    private var isIdChecked = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_signup)
 
+        btnCheckDuplicate = findViewById(R.id.btn_check_duplicate)
+        tvDuplicateStatus = findViewById(R.id.tv_duplicate_status)
         etName = findViewById(R.id.et_name)
         etEmail = findViewById(R.id.et_email)
         etPassword = findViewById(R.id.et_password)
@@ -73,9 +78,19 @@ class SignupActivity : AppCompatActivity() {
             override fun afterTextChanged(s: Editable?) = updateSignupButtonState()
         }
         etName.addTextChangedListener(watcher)
-        etEmail.addTextChangedListener(watcher)
         etPassword.addTextChangedListener(watcher)
         etPasswordConfirm.addTextChangedListener(watcher)
+
+        // 아이디가 변경되면 중복확인 상태 초기화
+        etEmail.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                isIdChecked = false
+                tvDuplicateStatus.visibility = View.GONE
+                updateSignupButtonState()
+            }
+        })
     }
 
     private fun setupPasswordToggles() {
@@ -169,12 +184,45 @@ class SignupActivity : AppCompatActivity() {
                 && etPassword.text.isNotEmpty()
                 && etPasswordConfirm.text.isNotEmpty()
         val agreementsChecked = cbTerms.isChecked && cbPrivacy.isChecked
-        val enabled = fieldsFilled && agreementsChecked
+        val enabled = fieldsFilled && agreementsChecked && isIdChecked
         btnSignup.isEnabled = enabled
         btnSignup.alpha = if (enabled) 1.0f else 0.5f
     }
 
     private fun setupClickListeners() {
+        btnCheckDuplicate.setOnClickListener {
+            val id = etEmail.text.toString().trim()
+            if (id.length < 6) {
+                etEmail.error = "아이디는 6자 이상이어야 합니다."
+                return@setOnClickListener
+            }
+            lifecycleScope.launch {
+                btnCheckDuplicate.isEnabled = false
+                try {
+                    val response = RetrofitClient.authApi.checkId(id)
+                    if (response.data) {
+                        isIdChecked = true
+                        tvDuplicateStatus.text = "사용 가능한 아이디입니다."
+                        tvDuplicateStatus.setTextColor(
+                            androidx.core.content.ContextCompat.getColor(
+                                this@SignupActivity, R.color.sub_200))
+                    } else {
+                        isIdChecked = false
+                        tvDuplicateStatus.text = "이미 사용 중인 아이디입니다."
+                        tvDuplicateStatus.setTextColor(
+                            androidx.core.content.ContextCompat.getColor(
+                                this@SignupActivity, R.color.red))
+                    }
+                    tvDuplicateStatus.visibility = View.VISIBLE
+                } catch (e: Exception) {
+                    Toast.makeText(this@SignupActivity, "중복 확인에 실패했습니다.", Toast.LENGTH_SHORT).show()
+                } finally {
+                    btnCheckDuplicate.isEnabled = true
+                    updateSignupButtonState()
+                }
+            }
+        }
+
         btnSignup.setOnClickListener {
             val name = etName.text.toString().trim()
             val email = etEmail.text.toString().trim()
@@ -183,6 +231,10 @@ class SignupActivity : AppCompatActivity() {
 
             if (email.length < 6) {
                 etEmail.error = "아이디는 6자 이상이어야 합니다."
+                return@setOnClickListener
+            }
+            if (!isIdChecked) {
+                Toast.makeText(this, "아이디 중복확인을 해주세요.", Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
             if (password.length < 6) {

--- a/app/src/main/java/com/example/reday/data/remote/AuthApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/AuthApiService.kt
@@ -3,7 +3,9 @@ package com.example.reday.data.remote
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 data class SignupRequest(
     val name: String,
@@ -44,7 +46,17 @@ data class LoginResponse(
     val data: LoginResponseData
 )
 
+data class CheckIdResponse(
+    val success: Boolean,
+    val code: Int,
+    val message: String,
+    val data: Boolean
+)
+
 interface AuthApiService {
+    @GET("api/auth/check-id")
+    suspend fun checkId(@Query("id") id: String): CheckIdResponse
+
     @POST("api/auth/signup")
     suspend fun signup(@Body request: SignupRequest): SignupResponse
 

--- a/app/src/main/java/com/example/reday/data/remote/RetrofitClient.kt
+++ b/app/src/main/java/com/example/reday/data/remote/RetrofitClient.kt
@@ -7,7 +7,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
 object RetrofitClient {
-    private val SPRING_BASE_URL = "http://reday-dev.duckdns.org:8080/"
+    private val SPRING_BASE_URL = "http://43.203.100.198:8080"
     private val AI_BASE_URL = "http://reday-dev.duckdns.org:8000/"
 
     var accessToken: String? = null

--- a/app/src/main/res/layout/activity_signup.xml
+++ b/app/src/main/res/layout/activity_signup.xml
@@ -142,7 +142,7 @@
                         </LinearLayout>
                     </LinearLayout>
 
-                    <!-- 이메일 -->
+                    <!-- 아이디 -->
                     <LinearLayout
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
@@ -152,43 +152,76 @@
                         <TextView
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:text="이메일"
+                            android:text="아이디"
                             android:textSize="14sp"
                             android:textColor="@color/brown_600"
                             android:textStyle="bold" />
 
                         <LinearLayout
                             android:layout_width="match_parent"
-                            android:layout_height="55dp"
+                            android:layout_height="wrap_content"
                             android:layout_marginTop="8dp"
-                            android:background="@drawable/selector_signup_input_bg"
-                            android:addStatesFromChildren="true"
                             android:orientation="horizontal"
-                            android:gravity="center_vertical"
-                            android:paddingStart="16dp"
-                            android:paddingEnd="16dp">
+                            android:gravity="center_vertical">
 
-                            <ImageView
-                                android:layout_width="20dp"
-                                android:layout_height="20dp"
-                                android:src="@drawable/ic_email"
-                                android:contentDescription="@null" />
-
-                            <EditText
-                                android:id="@+id/et_email"
+                            <LinearLayout
                                 android:layout_width="0dp"
-                                android:layout_height="match_parent"
+                                android:layout_height="55dp"
                                 android:layout_weight="1"
-                                android:layout_marginStart="10dp"
-                                android:background="@android:color/transparent"
-                                android:hint="example@reday.com"
-                                android:textColorHint="@color/brown_300"
-                                android:textColor="@color/brown_800"
-                                android:textSize="16sp"
-                                android:inputType="textEmailAddress"
-                                android:singleLine="true"
-                                android:imeOptions="actionNext" />
+                                android:background="@drawable/selector_signup_input_bg"
+                                android:addStatesFromChildren="true"
+                                android:orientation="horizontal"
+                                android:gravity="center_vertical"
+                                android:paddingStart="16dp"
+                                android:paddingEnd="16dp">
+
+                                <ImageView
+                                    android:layout_width="20dp"
+                                    android:layout_height="20dp"
+                                    android:src="@drawable/ic_email"
+                                    android:contentDescription="@null" />
+
+                                <EditText
+                                    android:id="@+id/et_email"
+                                    android:layout_width="0dp"
+                                    android:layout_height="match_parent"
+                                    android:layout_weight="1"
+                                    android:layout_marginStart="10dp"
+                                    android:background="@android:color/transparent"
+                                    android:hint="6자 이상 입력"
+                                    android:textColorHint="@color/brown_300"
+                                    android:textColor="@color/brown_800"
+                                    android:textSize="16sp"
+                                    android:inputType="text"
+                                    android:singleLine="true"
+                                    android:imeOptions="actionNext" />
+                            </LinearLayout>
+
+                            <com.google.android.material.button.MaterialButton
+                                android:id="@+id/btn_check_duplicate"
+                                android:layout_width="wrap_content"
+                                android:layout_height="55dp"
+                                android:layout_marginStart="8dp"
+                                android:text="중복확인"
+                                android:textSize="14sp"
+                                android:textColor="@color/brown_50"
+                                app:backgroundTint="@color/brown_400"
+                                app:cornerRadius="12dp"
+                                app:elevation="0dp"
+                                android:paddingStart="14dp"
+                                android:paddingEnd="14dp" />
+
                         </LinearLayout>
+
+                        <TextView
+                            android:id="@+id/tv_duplicate_status"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="6dp"
+                            android:layout_marginStart="4dp"
+                            android:textSize="12sp"
+                            android:visibility="gone" />
+
                     </LinearLayout>
 
                     <!-- 비밀번호 -->
@@ -230,7 +263,7 @@
                                 android:layout_weight="1"
                                 android:layout_marginStart="10dp"
                                 android:background="@android:color/transparent"
-                                android:hint="8자 이상 입력"
+                                android:hint="6자 이상 입력"
                                 android:textColorHint="@color/brown_300"
                                 android:textColor="@color/brown_800"
                                 android:textSize="16sp"


### PR DESCRIPTION
# 📌 Pull Request Title
feat: 회원가입 아이디 중복확인 기능 추가 및 캘린더 버그 수정 

---

# ✨ 작업 내용 (What)
- 회원가입 화면 아이디 입력 UI 변경 (이메일 → 아이디)
  - 회원가입 아이디 중복확인 버튼 및 결과 메시지 UI 추가
  - 회원가입 아이디 중복확인 API 연동
  - 캘린더 화면 가끔 안 보이는 버그 수정
  - Google Maps API Key 등록

---

# 🧩 변경 사항 (Changes)
  - activity_signup.xml — 이메일 라벨/힌트/inputType을 아이디 기준으로 변경, 중복확인 버튼·상태 텍스트 추가, 비밀번호 힌트 6자 이상으로 통일
  - AuthApiService.kt — CheckIdResponse 데이터 클래스 추가, GET /api/auth/check-id 엔드포인트 추가
  - SignupActivity.kt — 중복확인 버튼 클릭 시 API 호출 및 결과 표시, 중복확인 완료 전 시작하기 버튼 비활성화, 아이디 수정 시 확인 상태 초기화
  - CalendarFragment.kt — loadAndRender()에 try-catch 추가, onViewCreated 중복 호출 제거
  - local.properties — Google Maps API Key 추가 (gitignore 처리됨)


---

# 📸 스크린샷 (UI 변경 시 필수)
UI가 변경되었거나 추가된 경우 반드시 이미지 첨부

예:  
| Before | After |  
|--------|--------|  
| (이미지) | (이미지) |

---

# 🧪 테스트 방법 (How to Test)
  - 앱 실행 → 회원가입 이동
  - 아이디 6자 이상 입력 → 중복확인 버튼 클릭 → 사용 가능/불가 메시지 확인
  - 중복확인 완료 후 나머지 정보 입력 → 시작하기 버튼 활성화 확인
  - 아이디 수정 시 중복확인 상태 초기화 및 시작하기 버튼 비활성화 확인
  - 캘린더 탭 이동 후 캘린더 정상 렌더링 확인

---

# ✔ 체크리스트 (Checklist)
- [ ] 정상적으로 빌드됨
- [ ] Figma 디자인과 일치
- [ ] 불필요한 코드/주석 제거
- [ ] 브랜치 규칙 준수(feat/fix/design/refactor)
- [ ] 커밋 규칙 준수
- [ ] 충돌 확인

---

# 🔗 관련 이슈 (Optional)
- 이슈 번호: closed #42 
