### PR TITLE
feat: 기억 조각 수정 API 연동 및 UI 개선

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "mcp__plugin_figma_figma__get_design_context",
       "mcp__plugin_figma_figma__get_metadata",
       "mcp__plugin_figma_figma__whoami",
-      "Bash(xargs grep:*)"
+      "Bash(xargs grep:*)",
+      "Bash(grep -r \"delete\\\\|edit\\\\|update\\\\|modify\" app/src/main/java/com/example/reday/*.kt)"
     ]
   }
 }

--- a/app/src/main/java/com/example/reday/ArchiveMemoryAdapter.kt
+++ b/app/src/main/java/com/example/reday/ArchiveMemoryAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.lifecycle.LifecycleOwner
@@ -24,11 +25,15 @@ class ArchiveMemoryAdapter(
 ) : RecyclerView.Adapter<ArchiveMemoryAdapter.ViewHolder>() {
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val flThumbnail: FrameLayout = itemView.findViewById(R.id.fl_thumbnail)
+        val llCardBody: LinearLayout = itemView.findViewById(R.id.ll_card_body)
         val ivThumbnail: ImageView = itemView.findViewById(R.id.iv_thumbnail)
         val tvTitle: TextView = itemView.findViewById(R.id.tv_title)
+        val tvTitleBody: TextView = itemView.findViewById(R.id.tv_title_body)
         val tvLocationOverlay: TextView = itemView.findViewById(R.id.tv_location_overlay)
         val tvEmotion: TextView = itemView.findViewById(R.id.tv_emotion)
         val tvSummary: TextView = itemView.findViewById(R.id.tv_summary)
+        val ivLocationIcon: ImageView = itemView.findViewById(R.id.iv_location_icon_meta)
         val tvLocation: TextView = itemView.findViewById(R.id.tv_location)
         val tvMetaDot: TextView = itemView.findViewById(R.id.tv_meta_dot)
         val ivPeopleIcon: ImageView = itemView.findViewById(R.id.iv_people_icon)
@@ -46,7 +51,11 @@ class ArchiveMemoryAdapter(
         val item = items[position]
 
         // 썸네일
+        val density = holder.itemView.resources.displayMetrics.density
         if (!item.thumbnailPath.isNullOrBlank()) {
+            holder.flThumbnail.visibility = View.VISIBLE
+            holder.llCardBody.minimumHeight = 0
+            holder.tvTitleBody.visibility = View.GONE
             val scope = (holder.itemView.context as? LifecycleOwner)?.lifecycleScope
             scope?.launch {
                 val bitmap = withContext(Dispatchers.IO) {
@@ -58,10 +67,13 @@ class ArchiveMemoryAdapter(
                 }
             }
         } else {
-            holder.ivThumbnail.setImageResource(android.R.color.transparent)
+            holder.flThumbnail.visibility = View.GONE
+            holder.llCardBody.minimumHeight = (200 * density + 0.5f).toInt()
+            holder.tvTitleBody.text = item.title
+            holder.tvTitleBody.visibility = View.VISIBLE
         }
 
-        // 제목
+        // 제목 (썸네일 오버레이)
         holder.tvTitle.text = item.title
 
         // 썸네일 위 위치
@@ -85,10 +97,13 @@ class ArchiveMemoryAdapter(
         holder.tvSummary.text = item.previewText ?: ""
 
         // 위치
-        if (item.locationName != null) {
+        if (!item.locationName.isNullOrBlank()) {
+            holder.ivLocationIcon.visibility = View.VISIBLE
+            holder.tvLocation.visibility = View.VISIBLE
             holder.tvLocation.text = item.locationName
         } else {
-            holder.tvLocation.text = ""
+            holder.ivLocationIcon.visibility = View.GONE
+            holder.tvLocation.visibility = View.GONE
         }
 
         // 인물

--- a/app/src/main/java/com/example/reday/ArchiveSearchFragment.kt
+++ b/app/src/main/java/com/example/reday/ArchiveSearchFragment.kt
@@ -10,7 +10,6 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.ImageView
-import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -175,7 +174,7 @@ class ArchiveSearchFragment : Fragment() {
     // ── AI 자연어 검색 ──
 
     private fun triggerAiSearch(query: String) {
-        val pbLoading = view?.findViewById<ProgressBar>(R.id.pb_ai_search)
+        val pbLoading = view?.findViewById<View>(R.id.layout_ai_loading)
         pbLoading?.isVisible = true
 
         viewLifecycleOwner.lifecycleScope.launch {
@@ -210,7 +209,7 @@ class ArchiveSearchFragment : Fragment() {
                 Toast.makeText(requireContext(), "AI 검색에 실패했어요. 일반 검색으로 대신할게요.", Toast.LENGTH_SHORT).show()
                 performServerSearch(query, selectedTags)
             } finally {
-                pbLoading?.isVisible = false
+                pbLoading?.visibility = View.GONE
             }
         }
     }

--- a/app/src/main/java/com/example/reday/MemoryCardAdapter.kt
+++ b/app/src/main/java/com/example/reday/MemoryCardAdapter.kt
@@ -65,12 +65,13 @@ class MemoryCardAdapter(
         holder.itemView.setOnClickListener { onItemClick?.invoke(item) }
 
         if (!item.thumbnailPath.isNullOrBlank()) {
+            holder.ivThumbnail.visibility = View.VISIBLE
             val thumbnailPath = item.thumbnailPath!!
             val source: Any = if (thumbnailPath.startsWith("http")) thumbnailPath else java.io.File(thumbnailPath)
             ImageViewCompat.setImageTintList(holder.ivThumbnail, null)
             Glide.with(holder.itemView).load(source).centerCrop().placeholder(R.drawable.ic_nav_archive).into(holder.ivThumbnail)
         } else {
-            setDefaultThumbnail(holder.ivThumbnail)
+            holder.ivThumbnail.visibility = View.GONE
         }
     }
 
@@ -81,13 +82,4 @@ class MemoryCardAdapter(
         notifyDataSetChanged()
     }
 
-    private fun setDefaultThumbnail(iv: ImageView) {
-        iv.setImageResource(R.drawable.ic_nav_archive)
-        ImageViewCompat.setImageTintList(
-            iv,
-            android.content.res.ColorStateList.valueOf(
-                androidx.core.content.ContextCompat.getColor(iv.context, R.color.brown_300)
-            )
-        )
-    }
 }

--- a/app/src/main/java/com/example/reday/MemoryDetailActivity.kt
+++ b/app/src/main/java/com/example/reday/MemoryDetailActivity.kt
@@ -33,13 +33,23 @@ class MemoryDetailActivity : AppCompatActivity() {
     private lateinit var memoryRepository: MemoryRepository
     private lateinit var fragmentRepository: RecordFragmentRepository
 
+    private lateinit var flHero: FrameLayout
     private lateinit var ivHero: ImageView
+    private lateinit var vHeroGradient: View
+    private lateinit var llTitleOverlay: LinearLayout
     private lateinit var tvTitle: TextView
     private lateinit var tvDate: TextView
     private lateinit var tvLocation: TextView
     private lateinit var tvLocationDot: TextView
     private lateinit var ivLocationIcon: ImageView
     private lateinit var tvEmotion: TextView
+    private lateinit var llHeaderNoImage: LinearLayout
+    private lateinit var tvTitleNoImage: TextView
+    private lateinit var tvDateNoImage: TextView
+    private lateinit var tvLocationNoImage: TextView
+    private lateinit var tvLocationDotNoImage: TextView
+    private lateinit var ivLocationIconNoImage: ImageView
+    private lateinit var tvEmotionNoImage: TextView
     private lateinit var tvSummary: TextView
     private lateinit var chipGroupTags: ChipGroup
     private lateinit var tvFragmentCount: TextView
@@ -51,13 +61,23 @@ class MemoryDetailActivity : AppCompatActivity() {
 
         val date = intent.getStringExtra(EXTRA_DATE) ?: run { finish(); return }
 
+        flHero = findViewById(R.id.fl_hero)
         ivHero = findViewById(R.id.iv_hero)
+        vHeroGradient = findViewById(R.id.v_hero_gradient)
+        llTitleOverlay = findViewById(R.id.ll_title_overlay)
         tvTitle = findViewById(R.id.tv_title)
         tvDate = findViewById(R.id.tv_date)
         tvLocation = findViewById(R.id.tv_location)
         tvLocationDot = findViewById(R.id.tv_location_dot)
         ivLocationIcon = findViewById(R.id.iv_location_icon)
         tvEmotion = findViewById(R.id.tv_emotion)
+        llHeaderNoImage = findViewById(R.id.ll_header_no_image)
+        tvTitleNoImage = findViewById(R.id.tv_title_no_image)
+        tvDateNoImage = findViewById(R.id.tv_date_no_image)
+        tvLocationNoImage = findViewById(R.id.tv_location_no_image)
+        tvLocationDotNoImage = findViewById(R.id.tv_location_dot_no_image)
+        ivLocationIconNoImage = findViewById(R.id.iv_location_icon_no_image)
+        tvEmotionNoImage = findViewById(R.id.tv_emotion_no_image)
         tvSummary = findViewById(R.id.tv_summary)
         chipGroupTags = findViewById(R.id.chip_group_tags)
         tvFragmentCount = findViewById(R.id.tv_fragment_count)
@@ -131,36 +151,67 @@ class MemoryDetailActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val entity = memoryRepository.getMemoryByDate(date) ?: run { finish(); return@launch }
 
-            // 히어로 사진
+            // 히어로 사진 / 이미지 없을 때 헤더 분기
+            val location = entity.representativeLocationName
+                ?: parseLocations(entity.locations).firstOrNull()
+            val emotionEmoji = entity.emotion.toEmotionEmoji()
+            val dateLabel = formatDateLabel(date)
+
             if (!entity.representativePhotoUrl.isNullOrBlank()) {
+                // 이미지 있음: 히어로 영역 표시
                 val source: Any = if (entity.representativePhotoUrl!!.startsWith("http"))
                     entity.representativePhotoUrl!! else java.io.File(entity.representativePhotoUrl!!)
                 Glide.with(this@MemoryDetailActivity).load(source).centerCrop().into(ivHero)
-            }
+                flHero.layoutParams.height = (280 * resources.displayMetrics.density + 0.5f).toInt()
+                flHero.requestLayout()
+                ivHero.visibility = View.VISIBLE
+                vHeroGradient.visibility = View.VISIBLE
+                llTitleOverlay.visibility = View.VISIBLE
+                llHeaderNoImage.visibility = View.GONE
 
-            // 제목
-            tvTitle.text = entity.title
-
-            // 날짜
-            tvDate.text = formatDateLabel(date)
-
-            // 위치
-            val location = entity.representativeLocationName
-                ?: parseLocations(entity.locations).firstOrNull()
-            if (!location.isNullOrBlank()) {
-                tvLocation.text = location
-                tvLocation.visibility = View.VISIBLE
-                tvLocationDot.visibility = View.VISIBLE
-                ivLocationIcon.visibility = View.VISIBLE
-            }
-
-            // 감정 이모지
-            val emotionEmoji = entity.emotion.toEmotionEmoji()
-            if (!emotionEmoji.isNullOrBlank()) {
-                tvEmotion.text = emotionEmoji
-                tvEmotion.visibility = View.VISIBLE
+                tvTitle.text = entity.title
+                tvDate.text = dateLabel
+                if (!location.isNullOrBlank()) {
+                    tvLocation.text = location
+                    tvLocation.visibility = View.VISIBLE
+                    tvLocationDot.visibility = View.VISIBLE
+                    ivLocationIcon.visibility = View.VISIBLE
+                }
+                if (!emotionEmoji.isNullOrBlank()) {
+                    tvEmotion.text = emotionEmoji
+                    tvEmotion.visibility = View.VISIBLE
+                } else {
+                    tvEmotion.visibility = View.GONE
+                }
             } else {
-                tvEmotion.visibility = View.GONE
+                // 이미지 없음: 히어로를 툴바 높이로 축소, 별도 헤더 표시
+                flHero.layoutParams.height = (64 * resources.displayMetrics.density + 0.5f).toInt()
+                flHero.requestLayout()
+                ivHero.visibility = View.GONE
+                vHeroGradient.visibility = View.GONE
+                llTitleOverlay.visibility = View.GONE
+                llHeaderNoImage.visibility = View.VISIBLE
+
+                // 버튼 색 변경 (밝은 배경이므로 어두운 색으로)
+                val darkTint = android.content.res.ColorStateList.valueOf(
+                    ContextCompat.getColor(this@MemoryDetailActivity, R.color.brown_700))
+                ImageViewCompat.setImageTintList(findViewById(R.id.btn_back), darkTint)
+                ImageViewCompat.setImageTintList(findViewById(R.id.btn_more), darkTint)
+
+                tvTitleNoImage.text = entity.title
+                tvDateNoImage.text = dateLabel
+                if (!location.isNullOrBlank()) {
+                    tvLocationNoImage.text = location
+                    tvLocationNoImage.visibility = View.VISIBLE
+                    tvLocationDotNoImage.visibility = View.VISIBLE
+                    ivLocationIconNoImage.visibility = View.VISIBLE
+                }
+                if (!emotionEmoji.isNullOrBlank()) {
+                    tvEmotionNoImage.text = emotionEmoji
+                    tvEmotionNoImage.visibility = View.VISIBLE
+                } else {
+                    tvEmotionNoImage.visibility = View.GONE
+                }
             }
 
             // 요약

--- a/app/src/main/java/com/example/reday/MemoryFragmentActivity.kt
+++ b/app/src/main/java/com/example/reday/MemoryFragmentActivity.kt
@@ -255,14 +255,17 @@ class MemoryFragmentActivity : AppCompatActivity() {
         header.addView(chevron)
 
         if (isExpanded) {
-            val deleteBtn = ImageView(this).apply {
+            val editBtn = ImageView(this).apply {
                 layoutParams = LinearLayout.LayoutParams(20.dp, 20.dp).also {
                     it.marginStart = 10.dp
                 }
-                setImageResource(R.drawable.ic_delete)
-                setOnClickListener { showDeleteConfirmDialog(fragment) }
+                setImageResource(R.drawable.ic_edit)
+                ImageViewCompat.setImageTintList(this,
+                    android.content.res.ColorStateList.valueOf(
+                        ContextCompat.getColor(this@MemoryFragmentActivity, R.color.brown_400)))
+                setOnClickListener { showFragmentOptionsPopup(it, fragment) }
             }
-            header.addView(deleteBtn)
+            header.addView(editBtn)
         }
 
         container.addView(header)
@@ -505,6 +508,67 @@ class MemoryFragmentActivity : AppCompatActivity() {
         dialog.findViewById<android.widget.TextView>(R.id.btn_dialog_confirm).setOnClickListener {
             dialog.dismiss()
             startAiGeneration()
+        }
+        dialog.show()
+    }
+
+    private fun showFragmentOptionsPopup(anchor: View, fragment: RecordFragmentUiModel) {
+        val popup = android.widget.PopupMenu(this, anchor)
+        popup.menu.add(0, 0, 0, "수정")
+        popup.menu.add(0, 1, 1, "삭제")
+        popup.setOnMenuItemClickListener { item ->
+            when (item.itemId) {
+                0 -> { showEditDialog(fragment); true }
+                1 -> { showDeleteConfirmDialog(fragment); true }
+                else -> false
+            }
+        }
+        popup.show()
+    }
+
+    private fun showEditDialog(fragment: RecordFragmentUiModel) {
+        val dialog = android.app.Dialog(this)
+        dialog.setContentView(R.layout.dialog_edit_record)
+        dialog.window?.setBackgroundDrawableResource(android.R.color.transparent)
+
+        val tvTitle = dialog.findViewById<android.widget.TextView>(R.id.tv_edit_title)
+        val etContent = dialog.findViewById<android.widget.EditText>(R.id.et_edit_content)
+        val etLocation = dialog.findViewById<android.widget.EditText>(R.id.et_edit_location)
+
+        when (fragment.fragmentType) {
+            FragmentType.PHOTO -> tvTitle.text = "사진 기록 수정"
+            FragmentType.TEXT -> tvTitle.text = "텍스트 기록 수정"
+            FragmentType.VOICE -> tvTitle.text = "음성 기록 수정"
+        }
+
+        if (fragment.fragmentType == FragmentType.VOICE) {
+            etContent.hint = "텍스트 메모 (선택)"
+        }
+
+        etContent.setText(fragment.contentText ?: "")
+        etLocation.setText(fragment.locationName ?: "")
+
+        dialog.findViewById<android.widget.TextView>(R.id.btn_edit_cancel).setOnClickListener {
+            dialog.dismiss()
+        }
+        dialog.findViewById<android.widget.TextView>(R.id.btn_edit_confirm).setOnClickListener {
+            val newContent = etContent.text.toString().trim().ifEmpty { null }
+            val newLocation = etLocation.text.toString().trim().ifEmpty { null }
+            dialog.dismiss()
+            lifecycleScope.launch {
+                try {
+                    repository.updateFragment(
+                        model = fragment,
+                        textContent = newContent,
+                        address = newLocation,
+                        latitude = fragment.latitude,
+                        longitude = fragment.longitude
+                    )
+                    loadFragments()
+                } catch (e: Exception) {
+                    Toast.makeText(this@MemoryFragmentActivity, "수정 실패: ${e.message}", Toast.LENGTH_SHORT).show()
+                }
+            }
         }
         dialog.show()
     }

--- a/app/src/main/java/com/example/reday/SearchResultAdapter.kt
+++ b/app/src/main/java/com/example/reday/SearchResultAdapter.kt
@@ -26,7 +26,6 @@ class SearchResultAdapter(
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val ivThumbnail: ImageView = itemView.findViewById(R.id.iv_thumbnail)
         val flNoImageHeader: FrameLayout = itemView.findViewById(R.id.fl_no_image_header)
-        val tvNoImageTitle: TextView = itemView.findViewById(R.id.tv_no_image_title)
         val llCardContent: LinearLayout = itemView.findViewById(R.id.ll_card_content)
         val tvDate: TextView = itemView.findViewById(R.id.tv_date)
         val tvTitle: TextView = itemView.findViewById(R.id.tv_title)
@@ -48,7 +47,6 @@ class SearchResultAdapter(
         if (!item.thumbnailPath.isNullOrBlank()) {
             holder.ivThumbnail.visibility = View.VISIBLE
             holder.flNoImageHeader.visibility = View.GONE
-            holder.tvTitle.visibility = View.VISIBLE
             val scope = (holder.itemView.context as? LifecycleOwner)?.lifecycleScope
             scope?.launch {
                 val bitmap = withContext(Dispatchers.IO) {
@@ -62,8 +60,6 @@ class SearchResultAdapter(
         } else {
             holder.ivThumbnail.visibility = View.GONE
             holder.flNoImageHeader.visibility = View.VISIBLE
-            holder.tvNoImageTitle.text = item.title
-            holder.tvTitle.visibility = View.GONE
         }
 
         // 날짜 포맷: "2026-03-08" → "2026.03.08"

--- a/app/src/main/java/com/example/reday/SearchResultAdapter.kt
+++ b/app/src/main/java/com/example/reday/SearchResultAdapter.kt
@@ -3,6 +3,7 @@ package com.example.reday
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
@@ -24,6 +25,9 @@ class SearchResultAdapter(
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val ivThumbnail: ImageView = itemView.findViewById(R.id.iv_thumbnail)
+        val flNoImageHeader: FrameLayout = itemView.findViewById(R.id.fl_no_image_header)
+        val tvNoImageTitle: TextView = itemView.findViewById(R.id.tv_no_image_title)
+        val llCardContent: LinearLayout = itemView.findViewById(R.id.ll_card_content)
         val tvDate: TextView = itemView.findViewById(R.id.tv_date)
         val tvTitle: TextView = itemView.findViewById(R.id.tv_title)
         val layoutLocation: LinearLayout = itemView.findViewById(R.id.layout_location)
@@ -42,6 +46,9 @@ class SearchResultAdapter(
 
         // 썸네일
         if (!item.thumbnailPath.isNullOrBlank()) {
+            holder.ivThumbnail.visibility = View.VISIBLE
+            holder.flNoImageHeader.visibility = View.GONE
+            holder.tvTitle.visibility = View.VISIBLE
             val scope = (holder.itemView.context as? LifecycleOwner)?.lifecycleScope
             scope?.launch {
                 val bitmap = withContext(Dispatchers.IO) {
@@ -53,7 +60,10 @@ class SearchResultAdapter(
                 }
             }
         } else {
-            holder.ivThumbnail.setImageResource(android.R.color.transparent)
+            holder.ivThumbnail.visibility = View.GONE
+            holder.flNoImageHeader.visibility = View.VISIBLE
+            holder.tvNoImageTitle.text = item.title
+            holder.tvTitle.visibility = View.GONE
         }
 
         // 날짜 포맷: "2026-03-08" → "2026.03.08"

--- a/app/src/main/java/com/example/reday/data/remote/RecordApiService.kt
+++ b/app/src/main/java/com/example/reday/data/remote/RecordApiService.kt
@@ -76,6 +76,14 @@ data class SaveTextRecordRequest(
     val recordedAt: String? = null
 )
 
+data class UpdateRecordRequest(
+    val textContent: String?,
+    val recordDate: String,
+    val address: String?,
+    val latitude: Double?,
+    val longitude: Double?
+)
+
 interface RecordApiService {
 
     @POST("api/records/text")
@@ -103,6 +111,12 @@ interface RecordApiService {
         @Query("year") year: Int,
         @Query("month") month: Int
     ): GetRecordDatesResponse
+
+    @PUT("api/records/{recordId}")
+    suspend fun updateRecord(
+        @Path("recordId") recordId: Long,
+        @Body request: UpdateRecordRequest
+    ): SaveRecordResponse
 
     @DELETE("api/records/{recordId}")
     suspend fun deleteRecord(@Path("recordId") recordId: Long): SaveRecordResponse

--- a/app/src/main/java/com/example/reday/data/repository/RecordFragmentRepository.kt
+++ b/app/src/main/java/com/example/reday/data/repository/RecordFragmentRepository.kt
@@ -9,6 +9,7 @@ import com.example.reday.data.remote.RecordItemData
 import com.example.reday.data.remote.RecordSummaryData
 import com.example.reday.data.remote.RetrofitClient
 import com.example.reday.data.remote.SaveTextRecordRequest
+import com.example.reday.data.remote.UpdateRecordRequest
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
@@ -214,6 +215,31 @@ class RecordFragmentRepository(
         } catch (e: Exception) {
             Log.e("RecordRepo", "기록 요약 조회 실패: ${e.message}")
             null
+        }
+    }
+
+    suspend fun updateFragment(
+        model: RecordFragmentUiModel,
+        textContent: String?,
+        address: String?,
+        latitude: Double?,
+        longitude: Double?
+    ) {
+        val serverId = model.serverId ?: return
+        try {
+            api.updateRecord(
+                serverId,
+                UpdateRecordRequest(
+                    textContent = textContent,
+                    recordDate = model.date,
+                    address = address,
+                    latitude = latitude,
+                    longitude = longitude
+                )
+            )
+        } catch (e: Exception) {
+            Log.e("RecordRepo", "기록 수정 실패: ${e.message}")
+            throw e
         }
     }
 

--- a/app/src/main/res/layout/activity_memory_detail.xml
+++ b/app/src/main/res/layout/activity_memory_detail.xml
@@ -12,6 +12,7 @@
 
         <!-- 히어로 영역 -->
         <FrameLayout
+            android:id="@+id/fl_hero"
             android:layout_width="match_parent"
             android:layout_height="280dp">
 
@@ -25,6 +26,7 @@
 
             <!-- 어두운 그라디언트 오버레이 -->
             <View
+                android:id="@+id/v_hero_gradient"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@drawable/bg_hero_gradient" />
@@ -65,8 +67,9 @@
 
             </LinearLayout>
 
-            <!-- 제목 + 날짜 + 위치 (하단) -->
+            <!-- 제목 + 날짜 + 위치 (하단, 이미지 있을 때) -->
             <LinearLayout
+                android:id="@+id/ll_title_overlay"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="bottom"
@@ -142,6 +145,86 @@
                 </LinearLayout>
             </LinearLayout>
         </FrameLayout>
+
+        <!-- 이미지 없을 때 제목/날짜/위치 헤더 -->
+        <LinearLayout
+            android:id="@+id/ll_header_no_image"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/tv_title_no_image"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:textColor="@color/brown_800"
+                    android:textSize="22sp"
+                    android:textStyle="bold"
+                    android:lineSpacingMultiplier="1.2" />
+
+                <TextView
+                    android:id="@+id/tv_emotion_no_image"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textSize="24sp"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <TextView
+                    android:id="@+id/tv_date_no_image"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/brown_500"
+                    android:textSize="13sp" />
+
+                <TextView
+                    android:id="@+id/tv_location_dot_no_image"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=" · "
+                    android:textColor="@color/brown_400"
+                    android:textSize="13sp"
+                    android:visibility="gone" />
+
+                <ImageView
+                    android:id="@+id/iv_location_icon_no_image"
+                    android:layout_width="12dp"
+                    android:layout_height="12dp"
+                    android:src="@drawable/ic_location"
+                    android:tint="@color/brown_400"
+                    android:visibility="gone"
+                    android:contentDescription="위치" />
+
+                <TextView
+                    android:id="@+id/tv_location_no_image"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="2dp"
+                    android:textColor="@color/brown_500"
+                    android:textSize="13sp"
+                    android:visibility="gone" />
+
+            </LinearLayout>
+
+        </LinearLayout>
 
         <!-- AI 요약 카드 -->
         <com.google.android.material.card.MaterialCardView

--- a/app/src/main/res/layout/dialog_edit_record.xml
+++ b/app/src/main/res/layout/dialog_edit_record.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="300dp"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:background="@drawable/bg_dialog"
+    android:padding="24dp">
+
+    <ImageView
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@drawable/ic_edit"
+        android:background="@drawable/bg_circle_main105"
+        android:padding="12dp"
+        android:contentDescription="@null"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:id="@+id/tv_edit_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="기억 조각 수정"
+        android:textColor="@color/brown_800"
+        android:textSize="17sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="16dp" />
+
+    <EditText
+        android:id="@+id/et_edit_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="72dp"
+        android:gravity="top|start"
+        android:hint="내용"
+        android:textColorHint="@color/brown_300"
+        android:textColor="@color/brown_800"
+        android:textSize="14sp"
+        android:background="@drawable/bg_input_memo"
+        android:padding="12dp"
+        android:inputType="textMultiLine"
+        android:maxLines="4"
+        android:layout_marginBottom="8dp" />
+
+    <EditText
+        android:id="@+id/et_edit_location"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="위치 (선택)"
+        android:textColorHint="@color/brown_300"
+        android:textColor="@color/brown_800"
+        android:textSize="14sp"
+        android:background="@drawable/bg_input_field"
+        android:padding="12dp"
+        android:singleLine="true"
+        android:layout_marginBottom="20dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center">
+
+        <TextView
+            android:id="@+id/btn_edit_cancel"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="취소"
+            android:textColor="@color/brown_500"
+            android:textSize="14sp"
+            android:background="@drawable/bg_btn_cancel"
+            android:layout_marginEnd="8dp" />
+
+        <TextView
+            android:id="@+id/btn_edit_confirm"
+            android:layout_width="0dp"
+            android:layout_height="44dp"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="저장"
+            android:textColor="@color/brown_50"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:background="@drawable/bg_btn_voice_done" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_archive_search.xml
+++ b/app/src/main/res/layout/fragment_archive_search.xml
@@ -83,16 +83,6 @@
         android:layout_height="1dp"
         android:background="@color/brown_200" />
 
-    <!-- AI 검색 로딩 -->
-    <ProgressBar
-        android:id="@+id/pb_ai_search"
-        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:layout_width="match_parent"
-        android:layout_height="2dp"
-        android:indeterminate="true"
-        android:indeterminateTint="@color/main_200"
-        android:visibility="gone" />
-
     <!-- 태그 필터 패널 (필터 버튼 클릭 시 표시) -->
     <LinearLayout
         android:id="@+id/layout_filter_panel"
@@ -146,79 +136,110 @@
         android:background="@color/brown_200"
         android:visibility="gone" />
 
-    <!-- 빈 상태 / 결과 없음 -->
-    <LinearLayout
-        android:id="@+id/layout_empty"
+    <!-- 콘텐츠 + 로딩 오버레이 래퍼 -->
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:gravity="center"
-        android:visibility="visible">
+        android:layout_weight="1">
 
-        <FrameLayout
-            android:layout_width="72dp"
-            android:layout_height="72dp"
-            android:background="@drawable/bg_circle_sub100"
-            android:layout_marginBottom="20dp">
-
-            <ImageView
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:src="@drawable/ic_search"
-                android:layout_gravity="center"
-                android:tint="@color/sub_105" />
-
-        </FrameLayout>
-
-        <TextView
-            android:id="@+id/tv_empty_title"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="기억을 검색해보세요"
-            android:textColor="@color/brown_500"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            android:layout_marginBottom="8dp" />
-
-        <TextView
-            android:id="@+id/tv_empty_subtitle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="제목, 장소, 태그, 사람 등으로 검색할 수 있어요"
-            android:textColor="@color/brown_400"
-            android:textSize="13sp" />
-
-    </LinearLayout>
-
-    <!-- 검색 결과 -->
-    <LinearLayout
-        android:id="@+id/layout_result"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical"
-        android:visibility="gone">
-
-        <TextView
-            android:id="@+id/tv_result_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/brown_500"
-            android:textSize="13sp"
-            android:layout_marginHorizontal="16dp"
-            android:layout_marginTop="12dp"
-            android:layout_marginBottom="8dp" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/rv_search_result"
+        <!-- 빈 상태 / 결과 없음 -->
+        <LinearLayout
+            android:id="@+id/layout_empty"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:paddingHorizontal="12dp"
-            android:paddingBottom="16dp"
-            android:clipToPadding="false" />
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:visibility="visible">
 
-    </LinearLayout>
+            <FrameLayout
+                android:layout_width="72dp"
+                android:layout_height="72dp"
+                android:background="@drawable/bg_circle_sub100"
+                android:layout_marginBottom="20dp">
+
+                <ImageView
+                    android:layout_width="32dp"
+                    android:layout_height="32dp"
+                    android:src="@drawable/ic_search"
+                    android:layout_gravity="center"
+                    android:tint="@color/sub_105" />
+
+            </FrameLayout>
+
+            <TextView
+                android:id="@+id/tv_empty_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="기억을 검색해보세요"
+                android:textColor="@color/brown_500"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:layout_marginBottom="8dp" />
+
+            <TextView
+                android:id="@+id/tv_empty_subtitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="제목, 장소, 태그, 사람 등으로 검색할 수 있어요"
+                android:textColor="@color/brown_400"
+                android:textSize="13sp" />
+
+        </LinearLayout>
+
+        <!-- 검색 결과 -->
+        <LinearLayout
+            android:id="@+id/layout_result"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <TextView
+                android:id="@+id/tv_result_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/brown_500"
+                android:textSize="13sp"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="12dp"
+                android:layout_marginBottom="8dp" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_search_result"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:paddingHorizontal="12dp"
+                android:paddingBottom="16dp"
+                android:clipToPadding="false" />
+
+        </LinearLayout>
+
+        <!-- AI 검색 로딩 오버레이 -->
+        <LinearLayout
+            android:id="@+id/layout_ai_loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:background="@color/brown_100"
+            android:visibility="gone">
+
+            <ProgressBar
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:indeterminateTint="@color/main_200" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="AI가 기억을 찾고 있어요"
+                android:textColor="@color/brown_500"
+                android:textSize="13sp"
+                android:layout_marginTop="12dp" />
+
+        </LinearLayout>
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_archive_memory.xml
+++ b/app/src/main/res/layout/item_archive_memory.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="12dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="8dp"
     app:cardBackgroundColor="@color/brown_50"
     app:cardCornerRadius="16dp"
     app:cardElevation="2dp"
@@ -18,6 +19,7 @@
 
         <!-- 썸네일 영역 -->
         <FrameLayout
+            android:id="@+id/fl_thumbnail"
             android:layout_width="match_parent"
             android:layout_height="200dp">
 
@@ -66,10 +68,22 @@
 
         <!-- 카드 본문 -->
         <LinearLayout
+            android:id="@+id/ll_card_body"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:padding="14dp">
+
+            <!-- 이미지 없을 때 제목 -->
+            <TextView
+                android:id="@+id/tv_title_body"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/brown_800"
+                android:textSize="17sp"
+                android:textStyle="bold"
+                android:layout_marginBottom="8dp"
+                android:visibility="gone" />
 
             <!-- AI 요약 배지 + 감정 이모지 -->
             <LinearLayout
@@ -123,6 +137,7 @@
                 android:layout_marginBottom="10dp">
 
                 <ImageView
+                    android:id="@+id/iv_location_icon_meta"
                     android:layout_width="12dp"
                     android:layout_height="12dp"
                     android:src="@drawable/ic_location"
@@ -151,8 +166,7 @@
                     android:layout_height="12dp"
                     android:src="@drawable/ic_person"
                     android:tint="@color/brown_400"
-                    android:layout_marginEnd="3dp"
-                    android:visibility="gone" />
+                    android:layout_marginEnd="3dp" />
 
                 <TextView
                     android:id="@+id/tv_people"

--- a/app/src/main/res/layout/item_search_result.xml
+++ b/app/src/main/res/layout/item_search_result.xml
@@ -24,41 +24,21 @@
             android:scaleType="centerCrop"
             android:background="@color/brown_200" />
 
-        <!-- 이미지 없을 때 텍스트 헤더 -->
+        <!-- 이미지 없을 때 플레이스홀더 헤더 -->
         <FrameLayout
             android:id="@+id/fl_no_image_header"
             android:layout_width="match_parent"
             android:layout_height="120dp"
-            android:background="@color/main_100"
+            android:background="@color/inactive"
             android:visibility="gone">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:gravity="center_horizontal"
+            <ImageView
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:src="@drawable/ic_image"
+                android:tint="@color/brown_50"
                 android:layout_gravity="center"
-                android:paddingHorizontal="12dp">
-
-                <ImageView
-                    android:layout_width="24dp"
-                    android:layout_height="24dp"
-                    android:src="@drawable/ic_nav_archive"
-                    android:tint="@color/main_200"
-                    android:layout_marginBottom="8dp" />
-
-                <TextView
-                    android:id="@+id/tv_no_image_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:textColor="@color/brown_700"
-                    android:textSize="12sp"
-                    android:textStyle="bold"
-                    android:maxLines="2"
-                    android:ellipsize="end" />
-
-            </LinearLayout>
+                android:contentDescription="@null" />
 
         </FrameLayout>
 

--- a/app/src/main/res/layout/item_search_result.xml
+++ b/app/src/main/res/layout/item_search_result.xml
@@ -4,6 +4,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_margin="6dp"
     app:cardBackgroundColor="@color/brown_50"
     app:cardCornerRadius="12dp"
     app:cardElevation="2dp"
@@ -23,8 +24,47 @@
             android:scaleType="centerCrop"
             android:background="@color/brown_200" />
 
+        <!-- 이미지 없을 때 텍스트 헤더 -->
+        <FrameLayout
+            android:id="@+id/fl_no_image_header"
+            android:layout_width="match_parent"
+            android:layout_height="120dp"
+            android:background="@color/main_100"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center_horizontal"
+                android:layout_gravity="center"
+                android:paddingHorizontal="12dp">
+
+                <ImageView
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:src="@drawable/ic_nav_archive"
+                    android:tint="@color/main_200"
+                    android:layout_marginBottom="8dp" />
+
+                <TextView
+                    android:id="@+id/tv_no_image_title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:textColor="@color/brown_700"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:maxLines="2"
+                    android:ellipsize="end" />
+
+            </LinearLayout>
+
+        </FrameLayout>
+
         <!-- 카드 내용 -->
         <LinearLayout
+            android:id="@+id/ll_card_content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"


### PR DESCRIPTION
Summary                                                                                                                                                                                               

  기억 조각 수정 기능
  - PUT /api/records/{recordId} 엔드포인트 연동 (UpdateRecordRequest DTO 추가)
  - RecordFragmentRepository에 updateFragment() 메서드 추가
  - 타임라인에서 편집 아이콘 탭 시 "수정 / 삭제" 팝업 메뉴 표시 (기존 휴지통 아이콘 제거)
  - 수정 다이얼로그(dialog_edit_record.xml) 신규 추가

  기억 카드 이미지 없을 때 UI 처리
  - 홈 카드(MemoryCardAdapter): 썸네일 GONE 처리
  - 보관함 카드(ArchiveMemoryAdapter): 썸네일 영역 GONE, body에 제목 표시, minHeight로 카드 크기 유지
  - 기억 상세(MemoryDetailActivity): 히어로 이미지 없을 때 툴바 축소 + 별도 헤더 섹션 표시
  - 검색 결과 카드(SearchResultAdapter): inactive 배경 + ic_image 아이콘 플레이스홀더 헤더 표시

  보관함 카드 메타 정보
  - 위치 / 같이 한 친구 정보 없으면 아이콘 포함 전부 숨김 처리

  보관함 검색 화면
  - AI 검색 로딩 인디케이터를 얇은 바 → 중앙 오버레이 원형 스피너로 교체 (로딩 중 빈 화면 텍스트 가림)
  - 검색 결과 카드 간격(layout_margin="6dp") 추가

  Test Plan

  - 기억 조각 타임라인에서 편집 아이콘 탭 → 팝업 메뉴(수정/삭제) 확인
  - 수정 다이얼로그 저장 시 API 호출 후 목록 갱신 확인
  - 이미지 없는 기억 카드 홈/보관함/상세/검색 각각 UI 확인
  - 보관함 카드 위치·인물 없을 때 해당 영역 완전히 숨겨지는지 확인
  - 보관함 검색 AI 검색 시 로딩 오버레이 표시 확인
